### PR TITLE
Fix/vite8 rolldown asset naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yumeangelica.github.io",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "type": "module",
   "author": "yumeangelica",

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,8 @@ export default defineConfig({
       output: {
         chunkFileNames: 'js/[name]-[hash].js',
         entryFileNames: 'js/[name]-[hash].js',
-        assetFileNames: ({ name }) => {
+        assetFileNames: (info) => {
+          const name = info.name || info.names?.[0] || ''
           if (name.endsWith('.css')) {
             return 'css/[name]-[hash][extname]'
           }
@@ -50,5 +51,4 @@ export default defineConfig({
       }
     }
   },
-
 })


### PR DESCRIPTION
## Summary

Fixes production build failure caused by Rolldown's different `assetFileNames` API in Vite 8.

## Problem

Rolldown passes `names` (array) instead of `name` (string) to the `assetFileNames` function, causing `TypeError: Cannot read properties of undefined (reading 'endsWith')` during `vite build`.

## Fix

Updated `assetFileNames` to handle both Rollup (`name`) and Rolldown (`names`) formats with a safe fallback.