### PR TITLE
Ci/auto gh pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Lint, Test, Build
@@ -29,3 +32,54 @@ jobs:
 
       - name: Build
         run: bun run build
+
+  deploy:
+    name: Deploy GitHub Pages
+    needs: quality
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Deploy to gh-pages
+        run: |
+          set -e
+
+          BUILD_DIR="dist"
+          RELEASE_BRANCH="gh-pages"
+          VERSION="$(bun -p "require('./package.json').version")"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin "$RELEASE_BRANCH"
+          git add -f "$BUILD_DIR"
+          tree="$(git write-tree --prefix="$BUILD_DIR")"
+          git reset -- "$BUILD_DIR"
+          git update-index --refresh
+
+          tag="$(git rev-parse --short HEAD)"
+          commit="$(git commit-tree -p "refs/remotes/origin/$RELEASE_BRANCH" -m "Deploy $tag as version $VERSION" "$tree")"
+
+          git update-ref "refs/heads/$RELEASE_BRANCH" "$commit"
+          git push origin "refs/heads/$RELEASE_BRANCH"
+
+          if ! git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            git tag -a "v$VERSION" -m "Release tag for version $VERSION" "$commit"
+            git push origin "v$VERSION"
+          fi

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ UI strings live in [public/messages_en.json](public/messages_en.json). Add a new
 
 Component tests use Vitest and Vue Test Utils. See [src/__tests__](src/__tests__).
 
+## CI and Deployment
+
+Pull requests run lint, tests, and a production build in GitHub Actions. Pushes to `main` run the same quality checks and then deploy the built `dist` output to the `gh-pages` branch.
+
 ## Contact
 
 Contact details are listed on the portfolio site.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
- Adds automatic GitHub Pages deployment after successful main-branch CI
- Keeps pull requests limited to lint, test, and production build checks
- Deploys the built dist output to the gh-pages branch on pushes to main
- Keeps the local deploy.sh ignored and avoids making it a CI dependency
- Documents the CI and deployment flow in README
- Bumps version to 2.0.14

Validation:
- bun run lint
- bun run test
- bun run build