### PR TITLE
Content/update portfolio tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/public/data.json
+++ b/public/data.json
@@ -108,15 +108,17 @@
         "HTML5",
         "Bootstrap",
         "GitHub",
+        "Bun",
+        "Biome",
         "Vite",
         "Vitest"
       ],
       "additionalInfo": [
-        "A personal site to showcase my Vue.js frontend and UI design skills",
-        "Focus on front-end structure, accessibility and responsiveness",
-        "JSON-based i18n system for all UI texts, enabling easy language support",
-        "Includes component testing with Vitest",
-        "Version control and automated deployment via GitHub Pages"
+        "Personal Vue.js portfolio showcasing frontend structure, accessibility, responsiveness and project presentation",
+        "Vite-powered build setup with Bun as the package manager and locked dependency workflow",
+        "JSON-based i18n system for UI texts, project data and reusable content updates",
+        "Quality gates with Biome linting, Vitest component tests and content validation tests",
+        "GitHub Actions workflow for pull request checks and automated GitHub Pages deployment"
       ],
       "links": [
         {
@@ -618,6 +620,14 @@
         {
           "title": "Webpack",
           "url": "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/webpack/webpack-original-wordmark.svg"
+        },
+        {
+          "title": "Bun",
+          "url": "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/bun/bun-original.svg"
+        },
+        {
+          "title": "Biome",
+          "url": "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/biome/biome-original-wordmark.svg"
         }
       ]
     },


### PR DESCRIPTION
- Updates the Personal portfolio project description to reflect the current Bun, Biome, CI, testing, and GitHub Pages deployment setup
- Adds Bun and Biome to the portfolio project technology list
- Adds Bun and Biome entries to the shared technology data so they can render in the tech stack and project cards
- Uses Devicon URLs for both Bun and Biome icons

Validation:
- bun run lint
- bun run test
- bun run build