### PR TITLE
Chore/node24 actions env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Build and Deploy GitHub Pages

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 dist-ssr
 coverage
 *.local
+.pr-description.md
 
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Personal web development portfolio built with Vue 3 and Vite. Live site: https:/
 - `bun run build` - production build
 - `bun run preview` - preview production build
 - `bun run test` - run tests
+- `bun run pr-description` - generate a pull request description from the current branch
 - `bun run deploy` - build and deploy to GitHub Pages
+- `bun run patch-push` / `minor-push` / `major-push` - run local checks, bump version, push the current branch, and print a pull request link and description
 
 ## Internationalization
 
@@ -38,9 +40,9 @@ UI strings live in [public/messages_en.json](public/messages_en.json). Add a new
 
 Component tests use Vitest and Vue Test Utils. See [src/__tests__](src/__tests__).
 
-## CI and Deployment
+## Release Flow
 
-Pull requests run lint, tests, and a production build in GitHub Actions. Pushes to `main` run the same quality checks and then deploy the built `dist` output to the `gh-pages` branch.
+Release push scripts run lint, tests, and a production build locally before pushing a branch. After a pull request is merged into `main`, GitHub Actions builds the site and deploys the `dist` output to the `gh-pages` branch.
 
 ## Contact
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "biome format --write .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "pr-description": "bun run scripts/pr-description.js",
     "patch-push": "bun run scripts/release-push.js patch",
     "minor-push": "bun run scripts/release-push.js minor",
     "major-push": "bun run scripts/release-push.js major",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/scripts/pr-description.js
+++ b/scripts/pr-description.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 import { $ } from 'bun'
 
-const defaultOutputPath = null
+const defaultOutputPath = '.pr-description.md'
 const defaultBaseRef = 'origin/main'
 const validationCommands = ['bun run lint', 'bun run test', 'bun run build']
 

--- a/scripts/pr-description.js
+++ b/scripts/pr-description.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env bun
+import { $ } from 'bun'
+
+const defaultOutputPath = null
+const defaultBaseRef = 'origin/main'
+const validationCommands = ['bun run lint', 'bun run test', 'bun run build']
+
+const options = parseArgs(Bun.argv.slice(2))
+const baseRef = options.baseRef || (await getDefaultBaseRef())
+const branch = await getCurrentBranch()
+const changes = mergeChanges(
+  parseNameStatus(await textOrEmpty($`git diff --name-status ${`${baseRef}...HEAD`}`)),
+  parseNameStatus(await textOrEmpty($`git diff --cached --name-status`)),
+  parseNameStatus(await textOrEmpty($`git diff --name-status`)),
+  parseUntrackedFiles(await textOrEmpty($`git ls-files --others --exclude-standard`)),
+)
+const commits = parseLines(await textOrEmpty($`git log --format=%s ${`${baseRef}..HEAD`}`))
+const versionChange = await getVersionChange(baseRef)
+const markdown = buildMarkdown({ branch, changes, commits, versionChange, validated: options.validated })
+
+if (options.outputPath || defaultOutputPath) {
+  const outputPath = options.outputPath || defaultOutputPath
+  await Bun.write(outputPath, markdown)
+}
+
+console.log(markdown)
+
+function parseArgs(args) {
+  const parsed = {
+    baseRef: null,
+    outputPath: null,
+    validated: false,
+  }
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+
+    if (arg === '--validated') {
+      parsed.validated = true
+      continue
+    }
+
+    if (arg === '--base') {
+      parsed.baseRef = args[index + 1]
+      index += 1
+      continue
+    }
+
+    if (arg === '--write') {
+      const nextArg = args[index + 1]
+      parsed.outputPath = nextArg && !nextArg.startsWith('--') ? nextArg : '.pr-description.md'
+
+      if (parsed.outputPath === nextArg) {
+        index += 1
+      }
+
+      continue
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      console.log('Usage: bun run scripts/pr-description.js [--validated] [--base <ref>] [--write [path]]')
+      process.exit(0)
+    }
+
+    throw new Error(`Unknown option: ${arg}`)
+  }
+
+  return parsed
+}
+
+async function getDefaultBaseRef() {
+  if (await canResolve(defaultBaseRef)) {
+    return defaultBaseRef
+  }
+
+  return 'main'
+}
+
+async function canResolve(ref) {
+  try {
+    await $`git rev-parse --verify ${ref}`.quiet()
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function getCurrentBranch() {
+  return (await textOrEmpty($`git branch --show-current`)) || 'current branch'
+}
+
+async function textOrEmpty(command) {
+  try {
+    return (await command.text()).trim()
+  } catch {
+    return ''
+  }
+}
+
+function parseLines(output) {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function parseNameStatus(output) {
+  return parseLines(output).map((line) => {
+    const parts = line.split('\t')
+    const status = parts[0]
+    const file = parts.at(-1)
+
+    return { status, file }
+  })
+}
+
+function parseUntrackedFiles(output) {
+  return parseLines(output).map((file) => ({ status: 'A', file }))
+}
+
+function mergeChanges(...changeSets) {
+  const changesByFile = new Map()
+
+  for (const changeSet of changeSets) {
+    for (const change of changeSet) {
+      if (change.file) {
+        changesByFile.set(change.file, change)
+      }
+    }
+  }
+
+  return [...changesByFile.values()].sort((left, right) => left.file.localeCompare(right.file))
+}
+
+async function getVersionChange(baseRef) {
+  const currentPackageJson = JSON.parse(await Bun.file('package.json').text())
+  const basePackageJsonText = await textOrEmpty($`git show ${`${baseRef}:package.json`}`)
+
+  if (!basePackageJsonText) {
+    return null
+  }
+
+  const basePackageJson = JSON.parse(basePackageJsonText)
+
+  if (basePackageJson.version === currentPackageJson.version) {
+    return null
+  }
+
+  return {
+    from: basePackageJson.version,
+    to: currentPackageJson.version,
+  }
+}
+
+function buildMarkdown({ branch, changes, commits, versionChange, validated }) {
+  const summary = buildSummary({ changes, commits, versionChange })
+  const validationPrefix = validated ? 'Passed' : 'Run'
+
+  return [
+    '## Summary',
+    ...summary.map((item) => `- ${item}`),
+    '',
+    '## Validation',
+    ...validationCommands.map((command) => `- ${validationPrefix} \`${command}\`.`),
+    '',
+    '## Notes',
+    `- Branch: \`${branch}\`.`,
+    '- Target branch: `main`.',
+    '',
+  ].join('\n')
+}
+
+function buildSummary({ changes, commits, versionChange }) {
+  const files = changes.map((change) => change.file)
+  const summary = []
+
+  if (hasFile(files, '.github/workflows/deploy.yml')) {
+    addUnique(summary, 'Opt into the Node 24 JavaScript actions runtime for the deploy workflow.')
+  } else if (files.some((file) => file.startsWith('.github/workflows/'))) {
+    addUnique(summary, 'Update the GitHub Actions workflow configuration.')
+  }
+
+  if (hasFile(files, 'scripts/pr-description.js')) {
+    addUnique(summary, 'Add a local PR description generator for release branches.')
+  }
+
+  if (hasFile(files, 'scripts/release-push.js')) {
+    addUnique(summary, 'Print and save a ready-to-copy PR description after local release pushes.')
+  }
+
+  if (hasFile(files, 'scripts/deploy-gh-pages.js')) {
+    addUnique(summary, 'Update the Bun-based GitHub Pages deployment helper.')
+  }
+
+  if (hasFile(files, 'package.json')) {
+    if (versionChange) {
+      addUnique(summary, `Bump the package version from ${versionChange.from} to ${versionChange.to}.`)
+    } else {
+      addUnique(summary, 'Update package scripts for the local release workflow.')
+    }
+  }
+
+  if (hasFile(files, 'README.md')) {
+    addUnique(summary, 'Document the local release and PR description workflow.')
+  }
+
+  for (const commit of commits) {
+    const item = commitToSummary(commit)
+
+    if (item) {
+      addUnique(summary, item)
+    }
+  }
+
+  if (summary.length === 0) {
+    addUnique(summary, 'Update project files for this branch.')
+  }
+
+  return summary.slice(0, 5)
+}
+
+function hasFile(files, fileName) {
+  return files.includes(fileName)
+}
+
+function addUnique(items, item) {
+  if (!items.includes(item)) {
+    items.push(item)
+  }
+}
+
+function commitToSummary(commit) {
+  const cleaned = commit
+    .replace(/^[a-f0-9]{7,}\s+/i, '')
+    .replace(/^(feat|fix|chore|ci|docs|test|style|refactor)(\(.+\))?:\s*/i, '')
+    .trim()
+
+  if (!cleaned || /^(patch|minor|major|version) update$/i.test(cleaned)) {
+    return null
+  }
+
+  return `${cleaned.charAt(0).toUpperCase()}${cleaned.slice(1).replace(/[.!?]$/, '')}.`
+}

--- a/scripts/release-push.js
+++ b/scripts/release-push.js
@@ -122,6 +122,14 @@ async function main() {
 
   const remoteUrl = (await $`git remote get-url origin`.text()).trim()
   const compareUrl = getCompareUrl(remoteUrl, branch)
+  const prDescriptionPath = '.pr-description.md'
+  let prDescription = null
+
+  try {
+    prDescription = await $`bun run scripts/pr-description.js --validated --write ${prDescriptionPath}`.text()
+  } catch {
+    console.error('\nCould not generate the PR description, but the branch was pushed successfully.')
+  }
 
   console.log(`\nPushed ${branch}.`)
 
@@ -129,6 +137,11 @@ async function main() {
     console.log(`Open PR: ${compareUrl}`)
   } else {
     console.log('Open a PR from this branch on GitHub.')
+  }
+
+  if (prDescription) {
+    console.log(`\nPR description saved to ${prDescriptionPath}:`)
+    console.log(prDescription)
   }
 }
 


### PR DESCRIPTION
## Summary
- Opt into the Node 24 JavaScript actions runtime for the deploy workflow.
- Add a local PR description generator for release branches.
- Print and save a ready-to-copy PR description after local release pushes.
- Bump the package version from 2.1.1 to 2.1.2.
- Document the local release and PR description workflow.

## Validation
- Passed `bun run lint`.
- Passed `bun run test`.
- Passed `bun run build`.

## Notes
- Branch: `chore/node24-actions-env`.
- Target branch: `main`.
