### PR TITLE
Refactor/i18n and a11y improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ design/
 .github/skills/
 .github/prompts/
 .vscode/
+
+# Local-only AI agent guidance (not part of the published repo)
+AGENTS.md
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ AI-assisted tools may be used for planning, debugging, documentation, and review
 
 Most public copy lives in:
 
-- `public/messages_en.json` for home page, navigation, SEO, and labels
+- `public/messages_en.json` for content, navigation, SEO, and labels, grouped by topic (`intro`, `journey`, `certifications`, `contact`, `projects`, ...)
 - `public/data.json` for project cards and technology metadata
 - `README.md` for repository-level explanation
 - `index.html` and `src/seo.js` for fallback SEO metadata
@@ -121,6 +121,14 @@ bun run lint
 bun run test
 bun run build
 ```
+
+### Adding a new language
+
+The site uses a small custom i18n layer (`src/i18n.js`) that fetches `public/messages_<locale>.json` at startup. To add a locale:
+
+1. Copy `public/messages_en.json` to `public/messages_<locale>.json` (for example `messages_fi.json`) and translate the **values only** — keep the key structure and every `{placeholder}` name identical, so the same code resolves each key.
+2. Point the app at the new locale by passing it to `loadMessages('<locale>')` in `src/main.js`. The default is `DEFAULT_LOCALE` (`en`) from `src/i18n.js`; if a non-default locale fails to load, the app falls back to English automatically.
+3. Run the checks above. The content-quality tests verify that every translation key used in the components exists, which helps catch keys forgotten during translation.
 
 ## Release flow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/public/messages_en.json
+++ b/public/messages_en.json
@@ -1,6 +1,11 @@
 {
   "app": {
-    "mainContentLabel": "Main site content"
+    "mainContentAriaLabel": "Main site content"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Something went wrong loading the content. Please try again later.",
+    "externalLinkAriaLabel": "{label} (opens in new tab)"
   },
   "seo": {
     "home": {
@@ -13,15 +18,13 @@
     }
   },
   "nav": {
-    "mainNavigation": "Main navigation",
+    "ariaLabel": "Main navigation",
     "skipToContent": "Skip to main content",
+    "toggleAriaLabel": "Toggle navigation",
     "home": "Home",
     "projects": "Projects",
     "github": "GitHub",
-    "linkedin": "LinkedIn",
-    "toggleNavigation": "Toggle navigation",
-    "githubAriaLabel": "GitHub (opens in new tab)",
-    "linkedinAriaLabel": "LinkedIn (opens in new tab)"
+    "linkedin": "LinkedIn"
   },
   "footer": {
     "ariaLabel": "Site footer",
@@ -31,9 +34,9 @@
     "ariaLabel": "Scroll back to top",
     "title": "Back to top"
   },
-  "home": {
+  "intro": {
     "title": "Software Development Portfolio",
-    "introSegments": [
+    "segments": [
       {
         "text": "I'm an "
       },
@@ -59,10 +62,14 @@
         "text": " it matters."
       }
     ],
-    "techStackTitle": "Technologies & Tools",
-    "profilePicAlt": "Angelica's CV Profile Picture",
-    "journeyTitle": "Developer Journey",
-    "journeyItems": [
+    "profileImageAlt": "Angelica's profile picture"
+  },
+  "techStack": {
+    "title": "Technologies & Tools"
+  },
+  "journey": {
+    "title": "Developer Journey",
+    "items": [
       "Currently working at OP Pohjola as a Software Developer Trainee, building accessible frontend features with React, TypeScript, SCSS, and design-system components in an international, regulated agile environment.",
       "Also supporting REST API and Java/Spring Boot-related tasks, including maintenance and migration work where needed.",
       "Previously worked on a backend-focused full-stack team project for City of Helsinki / Virittämö, using JavaScript, TypeScript, Node.js, Express, React, and MongoDB.",
@@ -72,67 +79,98 @@
       "Additional studies in DevOps with Docker, Cyber Security, and Python Programming at the University of Helsinki.",
       "ICT degree from Business College Helsinki, graduating in April 2024 with a GPA of 4.95/5.",
       "Personal projects in web development, Python tooling, automation, and accessible user interfaces."
-    ],
-    "certificationsTitle": "Professional Certifications",
-    "certificationAriaLabel": "{text} (opens in new tab)",
-    "certifications": [
+    ]
+  },
+  "certifications": {
+    "title": "Professional Certifications",
+    "items": [
       {
         "text": "Microsoft Certified: Security, Compliance, and Identity Fundamentals (SC-900)",
         "url": "https://learn.microsoft.com/api/credentials/share/en-us/yumeangelica/5AC06C18FC8D561A?sharingId=34D975BF021B8BDF"
       }
-    ],
-    "interestingFactTitleStart": "A bit about my",
-    "yumeWord": "yume",
-    "yumeTooltip": "\"dream\"",
-    "yumeAriaLabel": "yume, meaning \"dream\"",
-    "interestingFactText": "Outside of coding, I produce music and explore Japanese culture. Those creative interests influence how I approach problem-solving, structure, and small details in user experiences.",
-    "drivesTitle": "What Drives Me",
-    "drivesSegments": [
+    ]
+  },
+  "yume": {
+    "titleStart": "A bit about my",
+    "word": "yume",
+    "tooltip": "\"dream\"",
+    "ariaLabel": "yume, meaning \"dream\"",
+    "text": "Outside of coding, I produce music and explore Japanese culture. Those creative interests influence how I approach problem-solving, structure, and small details in user experiences."
+  },
+  "drives": {
+    "title": "What Drives Me",
+    "segments": [
       {
         "text": "I'm currently open to new software developer opportunities where I can contribute to accessible, maintainable web applications and keep growing across modern frontend, full-stack JavaScript, and Python automation."
       }
-    ],
-    "contactTitle": "Get in Touch",
-    "contactEmail": "Reach out on LinkedIn if you would like to discuss a software development role or a relevant project.",
-    "contactSocial": "You can also find my work on GitHub.",
-    "contactImageAlt": "Reach out via LinkedIn",
-    "linkedinAriaLabel": "Visit my LinkedIn profile (opens in new tab)",
-    "githubAriaLabel": "Visit my GitHub profile (opens in new tab)",
-    "linkedinAlt": "LinkedIn logo and link",
-    "githubAlt": "GitHub logo and link"
+    ]
+  },
+  "contact": {
+    "title": "Get in Touch",
+    "linkedinPrompt": "Reach out on LinkedIn if you would like to discuss a software development role or a relevant project.",
+    "githubPrompt": "You can also find my work on GitHub.",
+    "imageAlt": "Reach out via LinkedIn",
+    "visitLinkedin": "Visit my LinkedIn profile",
+    "visitGithub": "Visit my GitHub profile"
   },
   "projects": {
     "title": "Selected Projects",
-    "filterAll": "All",
-    "filterFE": "FE",
-    "filterBE": "BE",
-    "filterFS": "FS",
-    "filterCLI": "CLI",
-    "filterAllTypesAria": "Show all types",
-    "filterFrontendAria": "Frontend projects",
-    "filterBackendAria": "Backend projects",
-    "filterFullstackAria": "Fullstack projects",
-    "filterCliAria": "CLI projects",
-    "filterAllTechAria": "Show all technologies",
-    "filterTechAria": "Filter by {title}",
-    "filterTypeGroupLabel": "Filter by project type",
-    "filterTechGroupLabel": "Filter by technology",
     "loading": "Loading projects...",
     "error": "Something went wrong loading the projects. Please try again later.",
-    "mainProjectsTitle": "Main Projects",
-    "fullstackProjectsTitle": "Full-stack Projects",
-    "frontendProjectsTitle": "Frontend Projects",
-    "backendProjectsTitle": "Backend Projects",
-    "cliProjectsTitle": "CLI Projects",
-    "floatingNavAria": "Quick navigation menu",
-    "floatingNavToggleAria": "Toggle quick navigation menu",
-    "floatingBackToTop": "Back to Top",
-    "floatingMain": "Main Projects",
-    "floatingFrontend": "Frontend",
-    "floatingBackend": "Backend",
-    "floatingFullstack": "Full-stack",
-    "floatingCli": "CLI",
-    "filterResultsCount": "{count} projects found"
+    "filters": {
+      "typeGroupAriaLabel": "Filter by project type",
+      "techGroupAriaLabel": "Filter by technology",
+      "allLabel": "All",
+      "allTypesAriaLabel": "Show all project types",
+      "allTechAriaLabel": "Show all technologies",
+      "types": {
+        "frontend": {
+          "label": "FE",
+          "ariaLabel": "Frontend projects"
+        },
+        "backend": {
+          "label": "BE",
+          "ariaLabel": "Backend projects"
+        },
+        "fullstack": {
+          "label": "FS",
+          "ariaLabel": "Full-stack projects"
+        },
+        "cli": {
+          "label": "CLI",
+          "ariaLabel": "CLI projects"
+        }
+      },
+      "techAriaLabel": "Filter by {title}",
+      "resultsFound": "{count} projects found",
+      "resultsFoundOne": "1 project found"
+    },
+    "sections": {
+      "main": {
+        "title": "Main Projects",
+        "navLabel": "Main Projects"
+      },
+      "fullstack": {
+        "title": "Full-stack Projects",
+        "navLabel": "Full-stack"
+      },
+      "frontend": {
+        "title": "Frontend Projects",
+        "navLabel": "Frontend"
+      },
+      "backend": {
+        "title": "Backend Projects",
+        "navLabel": "Backend"
+      },
+      "cli": {
+        "title": "CLI Projects",
+        "navLabel": "CLI"
+      }
+    },
+    "floatingNav": {
+      "ariaLabel": "Quick navigation menu",
+      "toggleAriaLabel": "Toggle quick navigation menu"
+    }
   },
   "projectCard": {
     "technologiesLabel": "Technologies used",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
       <TheHeaderPic />
       <TheNavBar />
     </header>
-    <main id="main-content" role="main" :aria-label="$t('app.mainContentLabel')">
+    <main id="main-content" role="main" :aria-label="$t('app.mainContentAriaLabel')">
       <div class="container-fluid">
         <div class="custom-container">
           <RouterView />

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -10,7 +10,7 @@ describe('App.vue', () => {
   const i18nMock = {
     $t: (key) => {
       const messages = {
-        'app.mainContentLabel': 'Main content'
+        'app.mainContentAriaLabel': 'Main content'
       }
       return messages[key] || key
     }

--- a/src/__tests__/PageHome.test.js
+++ b/src/__tests__/PageHome.test.js
@@ -9,41 +9,40 @@ vi.mock('../dataCache.js', () => ({
 const i18nMocks = {
   $t: (key) => {
     const messages = {
-      'home.title': 'Home',
-      'home.loading': 'Loading...',
-      'home.error': 'Failed to load data.',
-      'home.techStackTitle': 'Tech Stack',
-      'home.profilePicAlt': 'Profile picture',
-      'home.journeyTitle': 'Journey',
-      'home.certificationsTitle': 'Certifications',
-      'home.interestingFactTitleStart': 'Interesting',
-      'home.yumeAriaLabel': 'Yume',
-      'home.yumeWord': 'Yume',
-      'home.yumeTooltip': 'Dream',
-      'home.interestingFactText': 'Fact',
-      'home.drivesTitle': 'Drives',
-      'home.contactTitle': 'Contact',
-      'home.contactEmail': 'email@example.dev',
-      'home.contactImageAlt': 'Contact image',
-      'home.contactSocial': 'Social',
-      'home.linkedinAriaLabel': 'LinkedIn',
-      'home.linkedinAlt': 'LinkedIn logo',
-      'home.githubAriaLabel': 'GitHub',
-      'home.githubAlt': 'GitHub logo'
+      'intro.title': 'Home',
+      'common.loading': 'Loading...',
+      'common.error': 'Failed to load data.',
+      'common.externalLinkAriaLabel': '{label} (opens in new tab)',
+      'techStack.title': 'Tech Stack',
+      'intro.profileImageAlt': 'Profile picture',
+      'journey.title': 'Journey',
+      'certifications.title': 'Certifications',
+      'yume.titleStart': 'Interesting',
+      'yume.ariaLabel': 'Yume',
+      'yume.word': 'Yume',
+      'yume.tooltip': 'Dream',
+      'yume.text': 'Fact',
+      'drives.title': 'Drives',
+      'contact.title': 'Contact',
+      'contact.linkedinPrompt': 'email@example.dev',
+      'contact.imageAlt': 'Contact image',
+      'contact.githubPrompt': 'Social',
+      'contact.visitLinkedin': 'Visit my LinkedIn profile',
+      'contact.visitGithub': 'Visit my GitHub profile'
     }
     return messages[key] || key
   },
   $tm: (key) => {
-    if (key === 'home.journeyItems') {
+    if (key === 'journey.items') {
       return ['Milestone']
     }
-    if (key === 'home.certifications') {
+    if (key === 'certifications.items') {
       return [{ text: 'Cert', url: 'https://example.dev/cert' }]
     }
-    if (key === 'home.introSegments') {
+    if (key === 'intro.segments') {
       return [{ text: 'Intro text' }]
     }
-    if (key === 'home.drivesSegments') {
+    if (key === 'drives.segments') {
       return [{ text: 'Drive text' }]
     }
     return []

--- a/src/__tests__/TheNavBar.test.js
+++ b/src/__tests__/TheNavBar.test.js
@@ -5,15 +5,14 @@ describe('TheNavBar.vue', () => {
   const i18nMock = {
     $t: (key) => {
       const messages = {
-        'nav.mainNavigation': 'Main navigation',
+        'nav.ariaLabel': 'Main navigation',
         'nav.skipToContent': 'Skip to content',
-        'nav.toggleNavigation': 'Toggle navigation',
+        'nav.toggleAriaLabel': 'Toggle navigation',
         'nav.home': 'Home',
         'nav.projects': 'Projects',
         'nav.github': 'GitHub',
         'nav.linkedin': 'LinkedIn',
-        'nav.githubAriaLabel': 'Visit GitHub profile',
-        'nav.linkedinAriaLabel': 'Visit LinkedIn profile'
+        'common.externalLinkAriaLabel': '{label} (opens in new tab)'
       }
       return messages[key] || key
     },

--- a/src/__tests__/contentQuality.test.js
+++ b/src/__tests__/contentQuality.test.js
@@ -1,11 +1,26 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import { dirname, extname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { EN_FALLBACK } from '../i18n'
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 
 function readJson(path) {
   return JSON.parse(readFileSync(join(rootDir, path), 'utf8'))
+}
+
+// Resolve a dot-notation key against a nested messages object.
+function resolveKey(messages, key) {
+  return key.split('.').reduce((node, part) => (node == null ? undefined : node[part]), messages)
+}
+
+// Collect [dotPath, value] pairs for every non-object leaf (strings and arrays) in an object.
+function collectLeaves(value, path = []) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return Object.entries(value).flatMap(([key, item]) => collectLeaves(item, [...path, key]))
+  }
+
+  return [[path.join('.'), value]]
 }
 
 function collectFiles(dir, extensions) {
@@ -77,5 +92,47 @@ describe('content quality gates', () => {
     const filesWithVHtml = vueFiles.filter((file) => readFileSync(join(rootDir, file), 'utf8').includes('v-html'))
 
     expect(filesWithVHtml).toEqual([])
+  })
+
+  it('resolves every static translation key used in Vue components', () => {
+    const messages = readJson('public/messages_en.json')
+    const keyPattern = /\$tm?\(\s*'([^']+)'/g
+
+    const missing = collectFiles('src', ['.vue']).flatMap((file) => {
+      const content = readFileSync(join(rootDir, file), 'utf8')
+      return [...content.matchAll(keyPattern)]
+        .map((match) => match[1])
+        .filter((key) => {
+          const value = resolveKey(messages, key)
+          return typeof value !== 'string' && typeof value !== 'object'
+        })
+        .map((key) => ({ file, key }))
+    })
+
+    expect(missing).toEqual([])
+  })
+
+  it('keeps the built-in i18n fallback in sync with the message file', () => {
+    const messages = readJson('public/messages_en.json')
+
+    collectLeaves(EN_FALLBACK).forEach(([key, value]) => {
+      expect(resolveKey(messages, key), `EN_FALLBACK key "${key}" is missing or differs from messages_en.json`).toEqual(value)
+    })
+  })
+
+  it('defines the project section and type-filter keys built dynamically in the template', () => {
+    const messages = readJson('public/messages_en.json')
+
+    // Sections are keyed by `projects.sections.<type>.{title,navLabel}` via a template literal in PageProjects.vue.
+    for (const type of ['main', 'frontend', 'backend', 'fullstack', 'cli']) {
+      expect(typeof resolveKey(messages, `projects.sections.${type}.title`), `missing projects.sections.${type}.title`).toBe('string')
+      expect(typeof resolveKey(messages, `projects.sections.${type}.navLabel`), `missing projects.sections.${type}.navLabel`).toBe('string')
+    }
+
+    // Type filters are keyed by `projects.filters.types.<type>.{label,ariaLabel}` the same way.
+    for (const type of ['frontend', 'backend', 'fullstack', 'cli']) {
+      expect(typeof resolveKey(messages, `projects.filters.types.${type}.label`), `missing projects.filters.types.${type}.label`).toBe('string')
+      expect(typeof resolveKey(messages, `projects.filters.types.${type}.ariaLabel`), `missing projects.filters.types.${type}.ariaLabel`).toBe('string')
+    }
   })
 })

--- a/src/__tests__/i18n.test.js
+++ b/src/__tests__/i18n.test.js
@@ -73,7 +73,7 @@ describe('i18n', () => {
       global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 }))
 
       await loadMessages('en')
-      expect(t('home.title')).toBe('Software Development Portfolio')
+      expect(t('intro.title')).toBe('Software Development Portfolio')
       expect(t('nav.home')).toBe('Home')
     })
 

--- a/src/__tests__/scroll.test.js
+++ b/src/__tests__/scroll.test.js
@@ -1,0 +1,29 @@
+import { prefersReducedMotion, scrollBehavior } from '../scroll'
+
+describe('scroll helpers', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+  })
+
+  it('reports no reduced-motion preference when matchMedia is unavailable (e.g. jsdom)', () => {
+    // jsdom does not implement matchMedia; the helper must guard against it.
+    delete window.matchMedia
+    expect(prefersReducedMotion()).toBe(false)
+    expect(scrollBehavior()).toBe('smooth')
+  })
+
+  it('uses smooth scrolling when the user has not requested reduced motion', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false })
+    expect(prefersReducedMotion()).toBe(false)
+    expect(scrollBehavior()).toBe('smooth')
+  })
+
+  it('uses instant scrolling when the user prefers reduced motion', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true })
+    expect(prefersReducedMotion()).toBe(true)
+    expect(scrollBehavior()).toBe('auto')
+    expect(window.matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)')
+  })
+})

--- a/src/components/TheBackToTop.vue
+++ b/src/components/TheBackToTop.vue
@@ -1,12 +1,14 @@
 <template>
   <Transition name="fade">
-    <button v-if="isVisible" @click="scrollToTop" class="back-to-top" :aria-label="$t('backToTop.ariaLabel')" :title="$t('backToTop.title')">
+    <button v-if="isVisible" type="button" @click="scrollToTop" class="back-to-top" :aria-label="$t('backToTop.ariaLabel')" :title="$t('backToTop.title')">
       ↑
     </button>
   </Transition>
 </template>
 
 <script>
+import { scrollBehavior } from '../scroll';
+
 export default {
   name: 'TheBackToTop',
   data() {
@@ -29,7 +31,7 @@ export default {
     scrollToTop() {
       window.scrollTo({
         top: 0,
-        behavior: 'smooth'
+        behavior: scrollBehavior()
       });
     }
   },

--- a/src/components/TheNavBar.vue
+++ b/src/components/TheNavBar.vue
@@ -1,10 +1,10 @@
 <template>
-  <nav class="navbar navbar-expand-md navbar-light" role="navigation" :aria-label="$t('nav.mainNavigation')">
+  <nav class="navbar navbar-expand-md navbar-light" role="navigation" :aria-label="$t('nav.ariaLabel')">
     <a href="#main-content" class="visually-hidden-focusable">{{ $t('nav.skipToContent') }}</a>
     <div class="container-fluid">
       <!-- Toggler -->
       <button class="navbar-toggler ms-auto" type="button" @click="toggleNav" aria-controls="navbarNav" :aria-expanded="showNav ? 'true' : 'false'"
-        :aria-label="$t('nav.toggleNavigation')">
+        :aria-label="$t('nav.toggleAriaLabel')">
         <span class="navbar-toggler-icon"></span>
       </button>
       <!-- Navbar links -->
@@ -18,11 +18,11 @@
           </li>
           <li class="nav-item">
             <a href="https://github.com/yumeangelica" class="nav-link" target="_blank" rel="noopener" @click="closeNav"
-              :aria-label="$t('nav.githubAriaLabel')">{{ $t('nav.github') }}</a>
+              :aria-label="$t('common.externalLinkAriaLabel', { label: $t('nav.github') })">{{ $t('nav.github') }}</a>
           </li>
           <li class="nav-item">
             <a href="https://www.linkedin.com/in/yumeangelica/" class="nav-link" target="_blank" rel="noopener" @click="closeNav"
-              :aria-label="$t('nav.linkedinAriaLabel')">{{ $t('nav.linkedin') }}</a>
+              :aria-label="$t('common.externalLinkAriaLabel', { label: $t('nav.linkedin') })">{{ $t('nav.linkedin') }}</a>
           </li>
         </ul>
       </div>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -4,28 +4,35 @@ const state = reactive({
   messages: {}
 });
 
+/** Locale loaded by default and used as the fallback source for other locales. */
+const DEFAULT_LOCALE = 'en';
+
 /**
  * Minimal English fallback used only when the primary message file cannot
  * be fetched, so the app renders readable text instead of raw dot-keys.
  * The full copy lives in /public/messages_en.json.
  */
 const EN_FALLBACK = {
-  app: { mainContentLabel: 'Main site content' },
+  app: { mainContentAriaLabel: 'Main site content' },
+  common: {
+    loading: 'Loading...',
+    error: 'Something went wrong loading the content. Please try again later.'
+  },
   seo: {
     home: { title: "Angelica's portfolio | Software development" },
     projects: { title: "Angelica's projects | Selected software development work" }
   },
   nav: {
-    mainNavigation: 'Main navigation',
+    ariaLabel: 'Main navigation',
     skipToContent: 'Skip to main content',
     home: 'Home',
     projects: 'Projects',
     github: 'GitHub',
     linkedin: 'LinkedIn',
-    toggleNavigation: 'Toggle navigation'
+    toggleAriaLabel: 'Toggle navigation'
   },
   footer: { copyright: '© 2020 - {year} yumeangelica.github.io. All Rights Reserved.' },
-  home: { title: 'Software Development Portfolio' }
+  intro: { title: 'Software Development Portfolio' }
 };
 
 /**
@@ -37,7 +44,7 @@ function resolve(obj, path) {
 
 /**
  * Translate a message key with optional parameter interpolation.
- * @param {string} key - Dot-notation key (e.g. 'home.title')
+ * @param {string} key - Dot-notation key (e.g. 'intro.title')
  * @param {Object} params - Variables to interpolate (e.g. { year: 2026 })
  * @returns {string} Translated string, or the key itself if not found
  */
@@ -69,10 +76,10 @@ function tm(key) {
 
 /**
  * Load messages from a locale JSON file in /public.
- * Falls back to English if the requested locale fails.
- * @param {string} locale - Locale code (default: 'en')
+ * Falls back to the default locale if the requested locale fails.
+ * @param {string} locale - Locale code (default: DEFAULT_LOCALE)
  */
-async function loadMessages(locale = 'en') {
+async function loadMessages(locale = DEFAULT_LOCALE) {
   let loaded = false;
 
   try {
@@ -82,22 +89,22 @@ async function loadMessages(locale = 'en') {
     loaded = true;
   } catch (error) {
     console.error(`[i18n] Failed to load messages for locale "${locale}":`, error);
-    // If a non-English locale failed, try the English file as fallback
-    if (locale !== 'en') {
-      console.warn('[i18n] Falling back to English');
+    // If a non-default locale failed, try the default locale file as fallback
+    if (locale !== DEFAULT_LOCALE) {
+      console.warn(`[i18n] Falling back to "${DEFAULT_LOCALE}"`);
       try {
-        const fallback = await fetch('/messages_en.json');
+        const fallback = await fetch(`/messages_${DEFAULT_LOCALE}.json`);
         if (fallback.ok) {
           state.messages = await fallback.json();
           loaded = true;
         }
       } catch {
-        console.error('[i18n] Fallback to English also failed');
+        console.error(`[i18n] Fallback to "${DEFAULT_LOCALE}" also failed`);
       }
     }
   }
 
-  // If no message file loaded (e.g. the English file itself failed), seed a
+  // If no message file loaded (e.g. the default-locale file itself failed), seed a
   // minimal built-in fallback so the UI shows readable text instead of dot-keys.
   if (!loaded) {
     console.warn('[i18n] Using built-in English fallback messages');
@@ -116,4 +123,4 @@ const i18nPlugin = {
 };
 
 export default i18nPlugin;
-export { loadMessages, t, tm };
+export { loadMessages, t, tm, EN_FALLBACK, DEFAULT_LOCALE };

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import i18nPlugin, { loadMessages } from './i18n'
 
 import './main.css'
 
-loadMessages('en').then(() => {
+loadMessages().then(() => {
   const app = createApp(App)
 
   app.use(router)

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -1,14 +1,14 @@
 <template>
-  <h1>{{ $t('home.title') }}</h1>
+  <h1>{{ $t('intro.title') }}</h1>
 
   <!-- Loading state -->
   <div v-if="loading" class="text-center" role="status" aria-live="polite">
-    <p>{{ $t('home.loading') || 'Loading...' }}</p>
+    <p>{{ $t('common.loading') }}</p>
   </div>
 
   <!-- Error state -->
   <div v-else-if="fetchError" role="alert" class="error-message">
-    <p>{{ $t('home.error') || 'Failed to load data. Please try again later.' }}</p>
+    <p>{{ $t('common.error') }}</p>
   </div>
 
   <!-- Content -->
@@ -17,14 +17,14 @@
       <div class="col-lg-7">
 
         <p>
-          <template v-for="(segment, index) in $tm('home.introSegments')" :key="`intro-${index}`">
+          <template v-for="(segment, index) in $tm('intro.segments')" :key="`intro-${index}`">
             <span v-if="segment.type === 'highlight'" class="text-highlight">{{ segment.text }}</span>
             <em v-else-if="segment.type === 'emphasis'">{{ segment.text }}</em>
             <template v-else>{{ segment.text }}</template>
           </template>
         </p>
 
-        <h2 id="tech-stack">{{ $t('home.techStackTitle') }}</h2>
+        <h2 id="tech-stack">{{ $t('techStack.title') }}</h2>
         <!-- Display technologies in categories -->
         <div class="tech-category" v-for="category in categorizedTechnologies" :key="category.name"
           :aria-labelledby="'category-' + category.name.toLowerCase().replace(/\s+/g, '-')">
@@ -39,26 +39,26 @@
       </div>
 
       <div class="col-md-auto">
-        <img src="/assets/profile/angelica-profilepic.webp" class="img-responsive profilepic" :alt="$t('home.profilePicAlt')" fetchpriority="high">
+        <img src="/assets/profile/angelica-profilepic.webp" class="img-responsive profilepic" :alt="$t('intro.profileImageAlt')" fetchpriority="high">
       </div>
     </div>
 
     <section class="education">
       <div class="heartlist">
-        <h2>{{ $t('home.journeyTitle') }}</h2>
+        <h2>{{ $t('journey.title') }}</h2>
         <ul>
-          <li v-for="(item, index) in $tm('home.journeyItems')" :key="index">{{ item }}</li>
+          <li v-for="(item, index) in $tm('journey.items')" :key="index">{{ item }}</li>
         </ul>
       </div>
     </section>
 
     <section class="certifications">
       <div class="heartlist">
-        <h2>{{ $t('home.certificationsTitle') }}</h2>
+        <h2>{{ $t('certifications.title') }}</h2>
         <ul>
-          <li v-for="(cert, index) in $tm('home.certifications')" :key="index">
+          <li v-for="(cert, index) in $tm('certifications.items')" :key="index">
             <a class="styled-link" :href="cert.url" target="_blank" rel="noopener noreferrer"
-              :aria-label="$t('home.certificationAriaLabel', { text: cert.text })">
+              :aria-label="$t('common.externalLinkAriaLabel', { label: cert.text })">
               {{ cert.text }}
             </a>
           </li>
@@ -68,22 +68,22 @@
 
     <section class="interesting-fact">
       <h2>
-        {{ $t('home.interestingFactTitleStart') }}
-        <span class="tooltip-container" tabindex="0" :aria-label="$t('home.yumeAriaLabel')" @focus="isTooltipVisible = true"
+        {{ $t('yume.titleStart') }}
+        <span class="tooltip-container" tabindex="0" :aria-label="$t('yume.ariaLabel')" @focus="isTooltipVisible = true"
           @blur="isTooltipVisible = false">
-          {{ $t('home.yumeWord') }}
+          {{ $t('yume.word') }}
           <span class="tooltip-text" role="tooltip" aria-hidden="true" :class="{ 'visible': isTooltipVisible }">
-            {{ $t('home.yumeTooltip') }}
+            {{ $t('yume.tooltip') }}
           </span>
         </span>
       </h2>
-      <p>{{ $t('home.interestingFactText') }}</p>
+      <p>{{ $t('yume.text') }}</p>
     </section>
 
     <section class="commitment">
-      <h2>{{ $t('home.drivesTitle') }}</h2>
+      <h2>{{ $t('drives.title') }}</h2>
       <p>
-        <template v-for="(segment, index) in $tm('home.drivesSegments')" :key="`drives-${index}`">
+        <template v-for="(segment, index) in $tm('drives.segments')" :key="`drives-${index}`">
           <span v-if="segment.type === 'highlight'" class="text-highlight">{{ segment.text }}</span>
           <template v-else>{{ segment.text }}</template>
         </template>
@@ -92,24 +92,26 @@
     </section>
 
     <section class="contact">
-      <h2 id="contact">{{ $t('home.contactTitle') }}</h2>
-      <p>{{ $t('home.contactEmail') }}</p>
+      <h2 id="contact">{{ $t('contact.title') }}</h2>
+      <p>{{ $t('contact.linkedinPrompt') }}</p>
 
       <p class="introduction-highlights-paragraph">
-        <img class="contact-image" src="/assets/profile/angelica-contact.webp" :alt="$t('home.contactImageAlt')" loading="lazy" />
+        <img class="contact-image" src="/assets/profile/angelica-contact.webp" :alt="$t('contact.imageAlt')" loading="lazy" />
       </p>
 
-      <p>{{ $t('home.contactSocial') }}</p>
+      <p>{{ $t('contact.githubPrompt') }}</p>
 
       <p class="introduction-highlights-paragraph">
-        <a href="https://www.linkedin.com/in/yumeangelica/" target="_blank" :aria-label="$t('home.linkedinAriaLabel')" rel="noopener">
-          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original-wordmark.svg"
-            :alt="$t('home.linkedinAlt')" loading="lazy" />
+        <a href="https://www.linkedin.com/in/yumeangelica/" target="_blank"
+          :aria-label="$t('common.externalLinkAriaLabel', { label: $t('contact.visitLinkedin') })" rel="noopener">
+          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original-wordmark.svg" alt=""
+            loading="lazy" />
         </a>
 
-        <a href="https://github.com/yumeangelica" target="_blank" :aria-label="$t('home.githubAriaLabel')" rel="noopener">
-          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original-wordmark.svg"
-            :alt="$t('home.githubAlt')" loading="lazy" />
+        <a href="https://github.com/yumeangelica" target="_blank"
+          :aria-label="$t('common.externalLinkAriaLabel', { label: $t('contact.visitGithub') })" rel="noopener">
+          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original-wordmark.svg" alt=""
+            loading="lazy" />
         </a>
       </p>
     </section>

--- a/src/pages/PageProjects.vue
+++ b/src/pages/PageProjects.vue
@@ -7,36 +7,25 @@
     <div class="filter-container">
       <!-- Unified filter row: two centered rows, always visible on all devices -->
       <div class="filters-row">
-        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filterTypeGroupLabel')">
-          <button @click="toggleTypeFilter(null)" class="filter-btn filter-type" :class="{ active: selectedTypes.length === 0 }"
-            :aria-label="$t('projects.filterAllTypesAria')">
-            {{ $t('projects.filterAll') }}
+        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filters.typeGroupAriaLabel')">
+          <button type="button" @click="toggleTypeFilter(null)" class="filter-btn filter-type" :class="{ active: selectedTypes.length === 0 }"
+            :aria-label="$t('projects.filters.allTypesAriaLabel')">
+            {{ $t('projects.filters.allLabel') }}
           </button>
-          <button @click="toggleTypeFilter('frontend')" class="filter-btn filter-type" :class="{ active: selectedTypes.includes('frontend') }"
-            :disabled="!isTypeTechComboAvailable('frontend', selectedTech)" :aria-label="$t('projects.filterFrontendAria')">
-            {{ $t('projects.filterFE') }}
-          </button>
-          <button @click="toggleTypeFilter('backend')" class="filter-btn filter-type" :class="{ active: selectedTypes.includes('backend') }"
-            :disabled="!isTypeTechComboAvailable('backend', selectedTech)" :aria-label="$t('projects.filterBackendAria')">
-            {{ $t('projects.filterBE') }}
-          </button>
-          <button @click="toggleTypeFilter('fullstack')" class="filter-btn filter-type" :class="{ active: selectedTypes.includes('fullstack') }"
-            :disabled="!isTypeTechComboAvailable('fullstack', selectedTech)" :aria-label="$t('projects.filterFullstackAria')">
-            {{ $t('projects.filterFS') }}
-          </button>
-          <button @click="toggleTypeFilter('cli')" class="filter-btn filter-type" :class="{ active: selectedTypes.includes('cli') }"
-            :disabled="!isTypeTechComboAvailable('cli', selectedTech)" :aria-label="$t('projects.filterCliAria')">
-            {{ $t('projects.filterCLI') }}
+          <button type="button" v-for="type in typeFilters" :key="type" @click="toggleTypeFilter(type)" class="filter-btn filter-type"
+            :class="{ active: selectedTypes.includes(type) }" :disabled="!isTypeTechComboAvailable(type, selectedTech)"
+            :aria-label="$t(`projects.filters.types.${type}.ariaLabel`)">
+            {{ $t(`projects.filters.types.${type}.label`) }}
           </button>
         </div>
-        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filterTechGroupLabel')">
-          <button @click="toggleTechFilter(null)" class="filter-btn tech-filter-btn" :class="{ active: selectedTech.length === 0 }"
-            :aria-label="$t('projects.filterAllTechAria')">
-            <span>{{ $t('projects.filterAll') }}</span>
+        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filters.techGroupAriaLabel')">
+          <button type="button" @click="toggleTechFilter(null)" class="filter-btn tech-filter-btn" :class="{ active: selectedTech.length === 0 }"
+            :aria-label="$t('projects.filters.allTechAriaLabel')">
+            <span>{{ $t('projects.filters.allLabel') }}</span>
           </button>
-          <button v-for="tech in popularTechnologies" :key="tech.title" @click="toggleTechFilter(tech.title)" class="filter-btn tech-filter-btn"
+          <button type="button" v-for="tech in popularTechnologies" :key="tech.title" @click="toggleTechFilter(tech.title)" class="filter-btn tech-filter-btn"
             :class="{ active: selectedTech.includes(tech.title) }" :disabled="!isTechTypeComboAvailable(tech.title, selectedTypes)"
-            :aria-label="$t('projects.filterTechAria', { title: tech.title })">
+            :aria-label="$t('projects.filters.techAriaLabel', { title: tech.title })">
             <img :src="tech.url" :alt="tech.title" :title="tech.title" class="tech-icon" />
           </button>
         </div>
@@ -45,7 +34,7 @@
 
     <!-- Filter results count for screen readers -->
     <div v-if="!loading && !fetchError" class="visually-hidden" aria-live="polite" aria-atomic="true">
-      {{ $t('projects.filterResultsCount', { count: totalFilteredProjects }) }}
+      {{ resultsAnnouncement }}
     </div>
 
     <!-- Loading and error indicators -->
@@ -57,81 +46,31 @@
       <p>{{ $t('projects.error') }}</p>
     </div>
 
-    <!-- Main projects section -->
-    <section v-if="filteredMainProjects.length > 0" aria-labelledby="main-projects">
-      <h2 id="main-projects" class="text-center">{{ $t('projects.mainProjectsTitle') }}</h2>
+    <!-- Project sections, one per type that currently has matching projects -->
+    <section v-for="section in visibleSections" :key="section.type" :aria-labelledby="section.id">
+      <h2 :id="section.id" class="text-center">{{ $t(`projects.sections.${section.type}.title`) }}</h2>
       <div class="projects-container" aria-live="polite" :aria-busy="loading">
-        <TheProjectCard v-for="project in filteredMainProjects" :key="project.title" :project="project" :technologies="technologies" />
-      </div>
-    </section>
-
-    <!-- Fullstack projects section -->
-    <section v-if="filteredFullstackProjects.length > 0" aria-labelledby="fullstack-projects">
-      <h2 id="fullstack-projects" class="text-center">{{ $t('projects.fullstackProjectsTitle') }}</h2>
-      <div class="projects-container" aria-live="polite" :aria-busy="loading">
-        <TheProjectCard v-for="project in filteredFullstackProjects" :key="project.title" :project="project" :technologies="technologies" />
-      </div>
-    </section>
-
-
-    <!-- Frontend projects section -->
-    <section v-if="filteredFrontendProjects.length > 0" aria-labelledby="frontend-projects">
-      <h2 id="frontend-projects" class="text-center">{{ $t('projects.frontendProjectsTitle') }}</h2>
-      <div class="projects-container" aria-live="polite" :aria-busy="loading">
-        <TheProjectCard v-for="project in filteredFrontendProjects" :key="project.title" :project="project" :technologies="technologies" />
-      </div>
-    </section>
-
-    <!-- Backend projects section -->
-    <section v-if="filteredBackendProjects.length > 0" aria-labelledby="backend-projects">
-      <h2 id="backend-projects" class="text-center">{{ $t('projects.backendProjectsTitle') }}</h2>
-      <div class="projects-container" aria-live="polite" :aria-busy="loading">
-        <TheProjectCard v-for="project in filteredBackendProjects" :key="project.title" :project="project" :technologies="technologies" />
-      </div>
-    </section>
-
-
-    <!-- CLI projects section -->
-    <section v-if="filteredCliProjects.length > 0" aria-labelledby="cli-projects">
-      <h2 id="cli-projects" class="text-center">{{ $t('projects.cliProjectsTitle') }}</h2>
-      <div class="projects-container" aria-live="polite" :aria-busy="loading">
-        <TheProjectCard v-for="project in filteredCliProjects" :key="project.title" :project="project" :technologies="technologies" />
+        <TheProjectCard v-for="project in section.projects" :key="project.title" :project="project" :technologies="technologies" />
       </div>
     </section>
 
     <!-- Floating navigation - appears when scrolled down -->
     <Transition name="fade">
-      <div v-if="showFloatingNav" class="floating-nav" role="navigation" :aria-label="$t('projects.floatingNavAria')"
+      <div v-if="showFloatingNav" class="floating-nav" role="navigation" :aria-label="$t('projects.floatingNav.ariaLabel')"
         @keydown.esc="isFloatingMenuOpen = false">
-        <button @click="toggleFloatingMenu" class="floating-nav-toggle" :aria-expanded="isFloatingMenuOpen"
-          :aria-label="$t('projects.floatingNavToggleAria')">
+        <button type="button" @click="toggleFloatingMenu" class="floating-nav-toggle" :aria-expanded="isFloatingMenuOpen"
+          :aria-label="$t('projects.floatingNav.toggleAriaLabel')">
           <span class="nav-icon" :class="{ rotated: isFloatingMenuOpen }">☰</span>
         </button>
 
         <Transition name="slide-up">
           <div v-if="isFloatingMenuOpen" class="floating-nav-menu">
-            <button @click="scrollToSection('back-to-top')" class="floating-nav-button">
-              {{ $t('projects.floatingBackToTop') }}
+            <button type="button" @click="scrollToSection('back-to-top')" class="floating-nav-button">
+              {{ $t('backToTop.title') }}
             </button>
-            <button @click="scrollToSection('main-projects')" class="floating-nav-button" :class="{ disabled: !isMainVisible }"
-              :disabled="!isMainVisible">
-              {{ $t('projects.floatingMain') }}
-            </button>
-            <button @click="scrollToSection('frontend-projects')" class="floating-nav-button" :class="{ disabled: !isFrontendVisible }"
-              :disabled="!isFrontendVisible">
-              {{ $t('projects.floatingFrontend') }}
-            </button>
-            <button @click="scrollToSection('backend-projects')" class="floating-nav-button" :class="{ disabled: !isBackendVisible }"
-              :disabled="!isBackendVisible">
-              {{ $t('projects.floatingBackend') }}
-            </button>
-            <button @click="scrollToSection('fullstack-projects')" class="floating-nav-button" :class="{ disabled: !isFullstackVisible }"
-              :disabled="!isFullstackVisible">
-              {{ $t('projects.floatingFullstack') }}
-            </button>
-            <button @click="scrollToSection('cli-projects')" class="floating-nav-button" :class="{ disabled: !isCliVisible }"
-              :disabled="!isCliVisible">
-              {{ $t('projects.floatingCli') }}
+            <button type="button" v-for="type in floatingNavTypes" :key="type" @click="scrollToSection(`${type}-projects`)"
+              class="floating-nav-button" :class="{ disabled: !hasVisibleProjects(type) }" :disabled="!hasVisibleProjects(type)">
+              {{ $t(`projects.sections.${type}.navLabel`) }}
             </button>
           </div>
         </Transition>
@@ -143,6 +82,14 @@
 <script>
 import TheProjectCard from '../components/TheProjectCard.vue';
 import { fetchData } from '../dataCache.js';
+import { scrollBehavior } from '../scroll';
+
+// Project types shown as selectable type-filter buttons, in display order.
+const TYPE_FILTERS = ['frontend', 'backend', 'fullstack', 'cli'];
+// Project sections in the order they are rendered on the page.
+const SECTION_TYPES = ['main', 'fullstack', 'frontend', 'backend', 'cli'];
+// Section links in the floating quick-navigation menu, in menu order.
+const FLOATING_NAV_TYPES = ['main', 'frontend', 'backend', 'fullstack', 'cli'];
 
 export default {
   name: 'PageProjects',
@@ -189,47 +136,42 @@ export default {
       const technologies = Array.isArray(this.technologies) ? this.technologies : [];
       return technologies.filter(tech => techNames.includes(tech.title));
     },
-    filteredMainProjects() {
-      // Only main projects, filtered by type/tech
-      return this.filterProjects(this.mainProjects);
+    typeFilters() {
+      return TYPE_FILTERS;
     },
-    filteredFrontendProjects() {
-      // Only non-main frontend projects
-      return this.filterProjects(this.frontendProjects);
+    floatingNavTypes() {
+      return FLOATING_NAV_TYPES;
     },
-    filteredBackendProjects() {
-      return this.filterProjects(this.backendProjects);
+    // Projects for each section, filtered by the active type/tech selection.
+    filteredProjectsByType() {
+      return {
+        main: this.filterProjects(this.mainProjects),
+        fullstack: this.filterProjects(this.fullstackProjects),
+        frontend: this.filterProjects(this.frontendProjects),
+        backend: this.filterProjects(this.backendProjects),
+        cli: this.filterProjects(this.cliProjects),
+      };
     },
-    filteredFullstackProjects() {
-      return this.filterProjects(this.fullstackProjects);
-    },
-    filteredCliProjects() {
-      return this.filterProjects(this.cliProjects);
-    },
-    isMainVisible() {
-      return this.filteredMainProjects.length > 0;
-    },
-    isFrontendVisible() {
-      return this.filteredFrontendProjects.length > 0;
-    },
-    isBackendVisible() {
-      return this.filteredBackendProjects.length > 0;
-    },
-    isFullstackVisible() {
-      return this.filteredFullstackProjects.length > 0;
-    },
-    isCliVisible() {
-      return this.filteredCliProjects.length > 0;
+    // Sections with at least one matching project, in render order.
+    visibleSections() {
+      return SECTION_TYPES
+        .map(type => ({ type, id: `${type}-projects`, projects: this.filteredProjectsByType[type] }))
+        .filter(section => section.projects.length > 0);
     },
     totalFilteredProjects() {
-      return this.filteredMainProjects.length +
-        this.filteredFrontendProjects.length +
-        this.filteredBackendProjects.length +
-        this.filteredFullstackProjects.length +
-        this.filteredCliProjects.length;
+      return Object.values(this.filteredProjectsByType).reduce((total, list) => total + list.length, 0);
+    },
+    resultsAnnouncement() {
+      return this.totalFilteredProjects === 1
+        ? this.$t('projects.filters.resultsFoundOne')
+        : this.$t('projects.filters.resultsFound', { count: this.totalFilteredProjects });
     },
   },
   methods: {
+    // Whether a given section type currently has any matching project.
+    hasVisibleProjects(type) {
+      return this.filteredProjectsByType[type].length > 0;
+    },
     // Check if any project exists for the given type and selected techs
     isTypeTechComboAvailable(type, techArr) {
       const projects = Array.isArray(this.allProjects) ? this.allProjects : [];
@@ -307,7 +249,7 @@ export default {
       if (sectionId === 'back-to-top') {
         window.scrollTo({
           top: 0,
-          behavior: 'smooth'
+          behavior: scrollBehavior()
         });
         this.isFloatingMenuOpen = false; // Close menu after navigation
         return;
@@ -316,7 +258,7 @@ export default {
       // Regular section scrolling
       const element = document.getElementById(sectionId);
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        element.scrollIntoView({ behavior: scrollBehavior(), block: 'start' });
         this.isFloatingMenuOpen = false; // Close menu after navigation
       }
     },

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -1,0 +1,25 @@
+/**
+ * Programmatic-scroll helpers that respect the user's reduced-motion
+ * preference (WCAG 2.3.3). The global CSS `prefers-reduced-motion` rule
+ * cannot override JavaScript `scrollTo`/`scrollIntoView({ behavior: 'smooth' })`,
+ * so scroll call sites must pick their behavior explicitly.
+ */
+
+/**
+ * Whether the user has asked the OS/browser to reduce motion.
+ * @returns {boolean}
+ */
+export function prefersReducedMotion() {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Scroll behavior to use for programmatic scrolling: instant when the user
+ * prefers reduced motion, smooth otherwise.
+ * @returns {'auto' | 'smooth'}
+ */
+export function scrollBehavior() {
+  return prefersReducedMotion() ? 'auto' : 'smooth';
+}


### PR DESCRIPTION
## Summary

Restructures the site's i18n message layer into semantic, topic-based keys and fixes real bugs found along the way — including a broken loading/error state on the home page and a reduced-motion accessibility gap. No color-theme changes; the protected "a bit about my yume" copy is untouched.

## What changed

**i18n message refactor**
- Reorganized `public/messages_en.json` from a flat, page-scoped layout into topic-based namespaces (`intro`, `journey`, `certifications`, `contact`, `common`, ...). `seo.*` and `projects.*` are kept as deliberate exceptions (route-scoped / single coherent UI topic).
- Added a reusable `common.externalLinkAriaLabel` wrapper (`"{label} (opens in new tab)"`), removing six duplicated "(opens in new tab)" keys; nav and contact link aria-labels now compose from it.
- Light DRY of `PageProjects.vue`: `v-for` over type filters, project sections and floating-nav items driven by small ordered constants, replacing five near-identical section blocks and ten repetitive computeds. Section DOM ids, classes and ARIA are unchanged.
- Added `DEFAULT_LOCALE` and a README "Adding a new language" guide; the layer is now ready for future locales (e.g. Finnish) by translating values only.
- Added content-quality guard tests: every `$t`/`$tm` key used in components must resolve, and `EN_FALLBACK` must stay in sync with the message file.

**Bug fixes**
- Home loading/error states referenced non-existent keys (`home.loading`/`home.error`) and rendered the raw key string; now routed through `common.loading`/`common.error`.
- Programmatic scrolling ignored `prefers-reduced-motion` (WCAG 2.3.3). New `src/scroll.js` `scrollBehavior()` helper returns `auto` under reduced motion, `smooth` otherwise; used by back-to-top and floating-nav scrolls.
- Added `type="button"` to non-submit buttons.

**Copy polish (meaning preserved, voice preserved)**
- "Back to Top" → "Back to top", aria "Fullstack projects" → "Full-stack projects", profile alt → "Angelica's profile picture", "Show all types" → "Show all project types", singular "1 project found". Protected "a bit about my yume" left byte-identical.

**Chore**
- Git-ignore local-only `AGENTS.md` / `CLAUDE.md` agent-guidance files.
- Version bump 2.5.3 → 2.6.0.