### PR TITLE
Redesign/mobile first UI refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yumeangelica.github.io",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.14",

--- a/public/data.json
+++ b/public/data.json
@@ -20,11 +20,9 @@
       ],
       "additionalInfo": [
         "Public Vue 3 portfolio for selected software development projects and career background",
-        "Vite build setup with Bun package management and locked dependency workflow",
-        "JSON-based content structure for UI text, project data, and reusable copy updates",
-        "Quality checks with Biome linting, Vitest component tests, content validation tests, and production builds",
-        "Accessibility-minded UI with skip link, keyboard focus styles, semantic sections, alt text, and responsive layout",
-        "GitHub Actions workflow for pull request checks and GitHub Pages deployment"
+        "Accessible UI with skip link, keyboard focus styles, semantic sections, and responsive layout",
+        "Biome linting, Vitest component and content tests, and GitHub Actions deployment to GitHub Pages",
+        "Vite and Bun tooling with JSON-based content for UI text and project data"
       ],
       "links": [
         {
@@ -59,15 +57,11 @@
         "Vite"
       ],
       "additionalInfo": [
-        "Legacy full-stack pet care management app for coordinating daily care tasks within households",
-        "Recurring care-task generation with daily reset and carry-over behavior",
-        "Need completion tracking with quantities and durations",
-        "Owner and caretaker roles with authentication and hashed password storage",
-        "Timezone-aware scheduling for each user's local day boundary",
-        "Responsive Vue 3 UI with Pinia state management and Tailwind CSS",
-        "Node.js/Express REST API with MongoDB data model",
-        "Bun runtime and package management with Biome linting and Vitest tests",
-        "Single-container Docker deployment where one server serves the built Vue SPA and the Express API"
+        "Legacy full-stack pet care app for coordinating daily care tasks within households",
+        "Recurring care-task generation with daily reset, carry-over, quantities, and durations",
+        "Owner and caretaker roles with authentication, hashed passwords, and timezone-aware scheduling",
+        "Responsive Vue 3 UI with Pinia and Tailwind over a Node.js/Express REST API with MongoDB",
+        "Single-container Docker deployment with Bun, Biome linting, and Vitest tests"
       ],
       "links": [
         {
@@ -91,13 +85,10 @@
         "Raspberry Pi"
       ],
       "additionalInfo": [
-        "Python Discord bot for scheduled store-data monitoring and real-time product-change notifications to Discord channels",
-        "Async data extraction workflows with aiohttp, lxml, and curl_cffi browser impersonation",
-        "SQLite persistence for product history and price-change tracking",
-        "Configurable store sources and scheduling for personal/community use",
-        "Docker and Raspberry Pi deployment notes for a low-cost always-on setup",
-        "Typed Python structures with TypedDict and type hints",
-        "Responsible-use focus: allowed public sources, conservative scheduling, and no restricted, authenticated, or access-controlled sources"
+        "Python Discord bot for scheduled store monitoring and real-time product-change notifications",
+        "Async extraction with aiohttp, lxml, and curl_cffi; SQLite product and price history",
+        "Typed Python with configurable sources, plus Docker and Raspberry Pi deployment notes",
+        "Responsible-use focus with allowed public sources and conservative scheduling"
       ],
       "links": [
         {
@@ -123,14 +114,10 @@
         "GitHub"
       ],
       "additionalInfo": [
-        "Django-based weather forecast application with city search and external weather API integration",
-        "Current conditions and 3-day forecast with hourly breakdown",
-        "Displays temperature, humidity, wind speed, estimated UV index, sunrise, and sunset times",
-        "Estimated UV index calculated from solar position with pysolar, no paid UV API required",
-        "Optional auto-location detection based on IP address using GeoIP2",
-        "Environment-based API key configuration for OpenWeatherMap",
-        "Docker, Gunicorn, Nginx, WhiteNoise, and GitHub Actions oriented deployment setup",
-        "Responsive interface with clear search flow and public API integration proof"
+        "Django weather app with city search and OpenWeatherMap API integration",
+        "Current conditions and 3-day forecast with hourly breakdown, humidity, wind, and sun times",
+        "UV index estimated from solar position with pysolar, plus optional GeoIP2 auto-location",
+        "Deployment-oriented setup with Docker, Gunicorn, Nginx, WhiteNoise, and GitHub Actions"
       ],
       "links": [
         {
@@ -153,11 +140,9 @@
         "Docker"
       ],
       "additionalInfo": [
-        "Python module used as part of the Jirai Sweeties automation workflow",
-        "Scheduled product-data collection, parsing, and SQLite persistence",
-        "Configurable sources, structured data models, and typed Python data structures",
-        "Supports price and availability change tracking for allowed public sources",
-        "Supporting module for the Jirai Sweeties workflow; kept as secondary proof with responsible-use notes"
+        "Python module powering the Jirai Sweeties automation workflow",
+        "Scheduled data collection and parsing with SQLite persistence and typed data structures",
+        "Price and availability tracking for allowed public sources with responsible-use notes"
       ],
       "links": [
         {
@@ -187,14 +172,10 @@
         "GitHub"
       ],
       "additionalInfo": [
-        "Course-origin full-stack phonebook application with per-user private contacts",
-        "Register, login, logout, and delete-account flows with JWT-based authentication",
-        "Add, edit, delete, search, and paginate contacts",
-        "Form validation with visual feedback and international phone-number support",
-        "Responsive React UI built with Vite and a Node.js/Express and MongoDB backend",
-        "Bun runtime and package management with Biome linting",
-        "API and component testing with node:test and supertest where implemented",
-        "Supporting project proof for React, Node.js, Express, MongoDB, and testing basics"
+        "Course-origin full-stack phonebook app with per-user private contacts",
+        "JWT-based authentication with register, login, logout, and delete-account flows",
+        "Responsive React and Vite UI with form validation and international phone-number support",
+        "Node.js/Express and MongoDB backend with API tests using node:test and supertest"
       ],
       "links": [
         {
@@ -222,12 +203,9 @@
       ],
       "additionalInfo": [
         "Full-stack learning project for managing a personal book collection",
-        "PHP and MySQL application with Apache and Docker setup",
-        "User authentication, password change flow, and account-management safeguards",
-        "Prepared statements, password hashing, and input validation where implemented",
-        "ISBN validation with check-digit verification for ISBN-10 and ISBN-13",
-        "MVC-style structure with reusable components",
-        "Supporting proof for earlier full-stack and database work"
+        "PHP and MySQL with Apache and Docker in an MVC-style structure",
+        "User authentication and account safeguards with password hashing and prepared statements",
+        "Input validation including ISBN-10 and ISBN-13 check-digit verification"
       ],
       "links": [
         {
@@ -248,11 +226,9 @@
         "GitHub"
       ],
       "additionalInfo": [
-        "Python CLI for current weather conditions and short-term forecast lookup",
-        "Uses OpenWeatherMap API with environment-based API key configuration",
+        "Python CLI for current weather and short-term forecast lookup via OpenWeatherMap",
         "Shows current conditions, 3-day forecast, estimated UV index, and local times",
-        "Input validation, error handling, and timezone-aware display logic",
-        "Supporting Python API-integration and CLI proof"
+        "Input validation, error handling, timezone-aware display, and environment-based API keys"
       ],
       "links": [
         {

--- a/public/messages_en.json
+++ b/public/messages_en.json
@@ -120,6 +120,9 @@
     "filters": {
       "typeGroupAriaLabel": "Filter by project type",
       "techGroupAriaLabel": "Filter by technology",
+      "typeLabel": "Type",
+      "techLabel": "Technology",
+      "techToggleAriaLabel": "Toggle technology filters, {count} selected",
       "allLabel": "All",
       "allTypesAriaLabel": "Show all project types",
       "allTechAriaLabel": "Show all technologies",

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,36 +55,13 @@ body {
 .custom-container {
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 4px;
+  /* Fluid gutter replaces the old per-breakpoint margin overrides */
+  padding: 0 clamp(10px, 3vw, 25px);
 }
 
 main {
   flex-grow: 1;
   min-height: calc(90vh - 50px);
-}
-
-/* Tablet and small screen */
-@media (max-width: 1440px) {
-  .custom-container {
-    margin: 0 25px;
-    padding: 0 4px;
-  }
-}
-
-/* Mobile */
-@media (max-width: 768px) {
-  .custom-container {
-    margin: 0 15px;
-    padding: 0 4px;
-  }
-}
-
-/* Very small mobile */
-@media (max-width: 568px) {
-  .custom-container {
-    margin: 0 10px;
-    padding: 0 4px;
-  }
 }
 
 /* Add global focus styles for keyboard navigation */

--- a/src/__tests__/PageHome.test.js
+++ b/src/__tests__/PageHome.test.js
@@ -28,7 +28,9 @@ const i18nMocks = {
       'contact.imageAlt': 'Contact image',
       'contact.githubPrompt': 'Social',
       'contact.visitLinkedin': 'Visit my LinkedIn profile',
-      'contact.visitGithub': 'Visit my GitHub profile'
+      'contact.visitGithub': 'Visit my GitHub profile',
+      'nav.github': 'GitHub',
+      'nav.linkedin': 'LinkedIn'
     }
     return messages[key] || key
   },
@@ -109,5 +111,31 @@ describe('PageHome.vue', () => {
     expect(wrapper.find('img[alt="Vue.js"]').exists()).toBe(true)
     expect(wrapper.find('img[alt="TypeScript"]').exists()).toBe(true)
     expect(wrapper.find('img[alt="Node.js"]').exists()).toBe(true)
+  })
+
+  it('renders contact social buttons as safe external links', async () => {
+    fetchData.mockResolvedValueOnce({ technologies: [] })
+
+    const wrapper = mount(PageHome, {
+      global: {
+        mocks: i18nMocks
+      }
+    })
+
+    await flushPromises()
+
+    const buttons = wrapper.findAll('.contact-button')
+    expect(buttons.length).toBe(2)
+
+    const linkedin = buttons.find(link => link.text() === 'LinkedIn')
+    expect(linkedin.attributes('href')).toBe('https://www.linkedin.com/in/yumeangelica/')
+
+    const github = buttons.find(link => link.text() === 'GitHub')
+    expect(github.attributes('href')).toBe('https://github.com/yumeangelica')
+
+    buttons.forEach(link => {
+      expect(link.attributes('target')).toBe('_blank')
+      expect(link.attributes('rel')).toBe('noopener')
+    })
   })
 })

--- a/src/__tests__/PageProjects.test.js
+++ b/src/__tests__/PageProjects.test.js
@@ -72,6 +72,29 @@ describe('PageProjects.vue', () => {
     expect(filtered[0].title).toBe('Frontend Match')
   })
 
+  it('toggles the technology filter panel', async () => {
+    const wrapper = mount(PageProjects, {
+      global: {
+        mocks: i18nMocks,
+        stubs: {
+          TheProjectCard: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const toggle = wrapper.find('.filter-panel-toggle')
+
+    expect(wrapper.vm.isTechFiltersOpen).toBe(false)
+
+    await toggle.trigger('click')
+    expect(wrapper.vm.isTechFiltersOpen).toBe(true)
+
+    await toggle.trigger('click')
+    expect(wrapper.vm.isTechFiltersOpen).toBe(false)
+  })
+
   it('shows floating nav and closes menu after throttled scroll', async () => {
     Object.defineProperty(window, 'scrollY', {
       value: 250,

--- a/src/__tests__/TheNavBar.test.js
+++ b/src/__tests__/TheNavBar.test.js
@@ -108,6 +108,17 @@ describe('TheNavBar.vue', () => {
     vi.useRealTimers()
   })
 
+  it('closes navigation on Escape key', async () => {
+    const wrapper = createWrapper()
+    const toggler = wrapper.find('.navbar-toggler')
+
+    await toggler.trigger('click')
+    expect(wrapper.find('.navbar-collapse').classes()).toContain('show')
+
+    await wrapper.find('nav').trigger('keydown.esc')
+    expect(wrapper.find('.navbar-collapse').classes()).not.toContain('show')
+  })
+
   it('has correct aria-expanded attribute on toggler', async () => {
     const wrapper = createWrapper()
     const toggler = wrapper.find('.navbar-toggler')

--- a/src/__tests__/TheProjectCard.test.js
+++ b/src/__tests__/TheProjectCard.test.js
@@ -4,6 +4,7 @@ import TheProjectCard from 'components/TheProjectCard.vue'
 describe('TheProjectCard.vue', () => {
   const mockProject = {
     title: 'Vue Portfolio',
+    type: 'frontend',
     imageURL: 'https://assets.example.dev/image.jpg',
     imageWidth: 1000,
     imageHeight: 515,
@@ -31,7 +32,8 @@ describe('TheProjectCard.vue', () => {
           $t: (key, params = {}) => {
             const messages = {
               'projectCard.technologiesLabel': 'Technologies used',
-              'projectCard.linkAriaLabel': `Visit ${params.linkText} for ${params.projectTitle} (opens in new tab)`
+              'projectCard.linkAriaLabel': `Visit ${params.linkText} for ${params.projectTitle} (opens in new tab)`,
+              'projects.filters.types.frontend.label': 'Frontend'
             };
             return messages[key] || key;
           },
@@ -42,6 +44,15 @@ describe('TheProjectCard.vue', () => {
 
     // Project title
     expect(wrapper.text()).toContain(mockProject.title)
+
+    // Project type badge over the image
+    const badge = wrapper.find('.project-type-badge')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('Frontend')
+
+    // First additionalInfo item renders as the lead summary, the rest as list items
+    expect(wrapper.find('.project-summary').text()).toBe(mockProject.additionalInfo[0])
+    expect(wrapper.findAll('.project-highlights .additional-info')).toHaveLength(mockProject.additionalInfo.length - 1)
 
     // Project image
     const img = wrapper.find(`img[alt="${mockProject.title}"]`)
@@ -70,6 +81,29 @@ describe('TheProjectCard.vue', () => {
         new RegExp(`visit ${link.text} for ${mockProject.title}`, 'i')
       )
     })
+  })
+
+  it('collapses technology icons beyond eight into a +N chip', () => {
+    const manyTechs = Array.from({ length: 10 }, (_, i) => `Tech ${i + 1}`)
+    const wrapper = mount(TheProjectCard, {
+      props: {
+        project: { ...mockProject, technologyTitles: manyTechs },
+        technologies: manyTechs.map(title => ({ title, url: `https://cdn.example.dev/${title}.svg` }))
+      },
+      global: {
+        mocks: {
+          $t: (key) => key,
+          $tm: (key) => key
+        }
+      }
+    })
+
+    expect(wrapper.findAll('.small-devicon')).toHaveLength(8)
+    const moreChip = wrapper.find('.tech-chip-more')
+    expect(moreChip.exists()).toBe(true)
+    expect(moreChip.text()).toContain('+2')
+    // Hidden technologies stay available to assistive tech
+    expect(moreChip.text()).toContain('Tech 9, Tech 10')
   })
 
   it('does not render an icon for unknown technology titles', () => {

--- a/src/base.css
+++ b/src/base.css
@@ -21,8 +21,30 @@
   --color-button: rgb(148, 75, 118); /* project-card button background */
   --color-button-hover: rgb(130, 62, 100); /* project-card button hover background */
 
+  /* Derived tints — same palette, alpha/tint variants of the tokens above */
+  --color-primary-soft: rgba(241, 199, 232, 0.35); /* --color-primary-light at low alpha: section washes */
+  --color-border-soft: rgba(241, 199, 232, 0.65); /* --color-primary-light at 65% alpha: soft borders, photo ring */
+
+  /* Whisper surfaces — very pale pink and lilac card/menu backgrounds;
+     used instead of pure white so every surface stays in the palette */
+  --color-surface-pink: rgb(253, 244, 251);
+  --color-surface-lilac: rgb(247, 240, 252);
+
+  /* Shadows — layered and plum-tinted (from --color-primary-dark rgb(95, 41, 74)) for a softer feel than grey */
+  --shadow-sm: 0 1px 2px rgba(95, 41, 74, 0.08), 0 2px 8px rgba(95, 41, 74, 0.08);
+  --shadow-md: 0 2px 4px rgba(95, 41, 74, 0.1), 0 6px 16px rgba(95, 41, 74, 0.12);
+  --shadow-lg: 0 4px 8px rgba(95, 41, 74, 0.1), 0 12px 28px rgba(95, 41, 74, 0.16);
+
+  /* Radii */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-pill: 999px;
+
   /* Motion */
   --transition-duration: 0.6s; /* shared transition timing across interactive elements */
+  --transition-fast: 0.2s; /* hover/press microinteractions */
+  --transition-medium: 0.35s; /* menu/tooltip reveals */
 }
 
 

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -18,14 +18,24 @@ footer {
   width: 100%;
   color: var(--color-text);
   text-align: center;
-  padding: 15px;
-  margin-top: 20px;
+  padding: 20px 15px 24px;
+  margin-top: clamp(24px, 4vw, 40px);
+  font-size: 0.9rem;
+  /* Soft hairline above, same divider language as the page sections */
+  background: linear-gradient(to right, transparent, var(--color-primary-light), transparent) top center / min(420px, 70%) 1px no-repeat;
+}
+
+/* Decorative ♡ before the copyright; pseudo-content with empty alt so
+   screen readers skip it */
+footer::before {
+  content: '♡  ' / '';
+  color: var(--color-primary);
 }
 
 @media (max-width: 568px) {
   footer {
-    font-size: 0.65rem;
-    padding: 15px 5px;
+    font-size: 0.8rem;
+    padding: 18px 5px 20px;
   }
 }
 </style>

--- a/src/components/TheHeaderPic.vue
+++ b/src/components/TheHeaderPic.vue
@@ -11,12 +11,19 @@ export default {
 
 <style>
 .header-pic {
+  position: relative;
   background-image: url(/assets/profile/sakurabanner.webp);
   background-position: center;
   background-size: cover;
-  padding: 25px 20px 5px;
-  text-align: center;
-  height: 100px;
-  opacity: 0.7;
+  height: clamp(110px, 16vw, 170px);
+}
+
+/* Soft veil instead of element opacity: mutes the photo and melts it into
+   the pink navbar below for a dreamier, less abrupt cut. */
+.header-pic::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(255, 250, 253, 0.4), rgba(255, 250, 253, 0.2) 45%, rgba(241, 199, 232, 0.45));
 }
 </style>

--- a/src/components/TheNavBar.vue
+++ b/src/components/TheNavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="navbar navbar-expand-md navbar-light" role="navigation" :aria-label="$t('nav.ariaLabel')">
+  <nav class="navbar navbar-expand-md navbar-light" role="navigation" :aria-label="$t('nav.ariaLabel')" @keydown.esc="closeNav">
     <a href="#main-content" class="visually-hidden-focusable">{{ $t('nav.skipToContent') }}</a>
     <div class="container-fluid">
       <!-- Toggler -->
@@ -97,15 +97,41 @@ export default {
 /* Navbar overall styling */
 nav {
   background: var(--color-nav-bg);
-  margin-bottom: 40px;
-  padding: 4px 0;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  margin-bottom: clamp(28px, 4vw, 44px);
+  padding: 6px 0;
+  box-shadow: var(--shadow-sm);
 }
 
 /* Navbar link styling */
 .nav-link {
+  position: relative;
   color: var(--color-primary);
-  transition: color 0.3s ease-in-out;
+  transition: color var(--transition-fast) ease-in-out;
+}
+
+/* Soft gradient underline that scales in on hover/focus and stays visible
+   on the active route — calmer than the old background-fill jump. */
+.nav-link::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 0.2em;
+  width: min(100%, 3.5em);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(to right, transparent, var(--color-primary), transparent);
+  transform: translateX(-50%) scaleX(0);
+  transition: transform var(--transition-fast) ease;
+}
+
+.nav-link:hover::after,
+.nav-link:focus-visible::after,
+.nav-link.router-link-active::after {
+  transform: translateX(-50%) scaleX(1);
+}
+
+.nav-link:hover {
+  color: var(--color-primary-dark);
 }
 
 .nav-link.router-link-active {
@@ -120,17 +146,9 @@ nav {
   padding: 0 6px;
 }
 
-/* Hover and focus effects for nav items */
-.nav-item:hover,
-.nav-item:focus {
-  background-color: var(--color-primary-light);
-  color: var(--color-primary);
-  border-radius: 5px;
-}
-
-/* Navbar toggler icon customization */
+/* Navbar toggler icon customization — stroke uses the palette primary rgb(178, 77, 137) */
 .navbar-light .navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='rgb(252, 122, 191)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>");
+  background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke='rgb(178, 77, 137)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg>");
 }
 
 /* Toggler button styling */
@@ -214,6 +232,12 @@ nav {
   /* Smaller mobile nav text is normal-size: use the darker token for AA contrast on the pink menu background */
   .nav-link {
     color: var(--color-primary-dark);
+    /* Comfortable touch rows in the dropdown */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0.25rem 1rem;
   }
 
   .nav-link.router-link-active {
@@ -228,22 +252,25 @@ nav {
     transform: none;
     max-width: calc(100vw - 20px);
     background-color: var(--color-nav-bg);
-    border-radius: 15px;
-    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.1);
-    padding: 20px 25px;
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    padding: 14px 22px;
     z-index: 1000;
+  }
+
+  /* Gentle reveal for the dropdown; frozen harmlessly by the global
+     prefers-reduced-motion override. */
+  .navbar-collapse.show-animate {
+    animation: nav-menu-in var(--transition-fast) ease;
+    transform-origin: top right;
   }
 
   .nav-item {
     width: 100%;
     text-align: center;
     font-size: 1rem;
-    padding: 5px 10px;
-  }
-
-  .nav-item:focus,
-  .nav-item:hover {
-    background-color: var(--color-primary-light);
+    padding: 0;
   }
 
   .navbar-nav {
@@ -252,6 +279,18 @@ nav {
 
   nav {
     position: relative;
+  }
+}
+
+@keyframes nav-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 </style>

--- a/src/components/TheProjectCard.vue
+++ b/src/components/TheProjectCard.vue
@@ -2,19 +2,28 @@
   <article class="project-card">
     <div class="project-image-container">
       <img :src="project.imageURL" :alt="projectTitle" :width="project.imageWidth" :height="project.imageHeight" loading="lazy" />
+      <span v-if="project.type" class="project-type-badge">{{ $t(`projects.filters.types.${project.type}.label`) }}</span>
     </div>
 
     <div class="project-details">
       <h3>{{ projectTitle }}</h3>
+      <p v-if="summary" class="project-summary">{{ summary }}</p>
       <div class="used-technologies" role="group" :aria-label="$t('projectCard.technologiesLabel')">
-        <template v-for="techName in technologyTitles" :key="techName">
-          <img v-if="getTechIconUrl(techName)" class="small-devicon" :src="getTechIconUrl(techName)" :alt="techName" :title="techName"
-            loading="lazy" />
+        <template v-for="techName in visibleTechs" :key="techName">
+          <span v-if="getTechIconUrl(techName)" class="tech-chip" :title="techName">
+            <img class="small-devicon" :src="getTechIconUrl(techName)" :alt="techName" loading="lazy" />
+          </span>
         </template>
+        <span v-if="extraTechs.length" class="tech-chip tech-chip-more" :title="extraTechs.join(', ')">
+          <span aria-hidden="true">+{{ extraTechs.length }}</span>
+          <span class="visually-hidden">{{ extraTechs.join(', ') }}</span>
+        </span>
       </div>
-      <p v-for="info in additionalInfo" :key="info" class="heartbefore additional-info">
-        {{ info }}
-      </p>
+      <ul v-if="highlights.length" class="project-highlights">
+        <li v-for="info in highlights" :key="info" class="additional-info">
+          {{ info }}
+        </li>
+      </ul>
       <div class="buttons">
         <a v-for="link in links" :key="link.text" :href="link.url" class="project-button" target="_blank" rel="noopener"
           :aria-label="$t('projectCard.linkAriaLabel', { linkText: link.text, projectTitle: projectTitle })">
@@ -27,6 +36,10 @@
 
 
 <script>
+// Icons beyond this count collapse into a "+N" chip so long stacks
+// (e.g. 16 technologies) don't overwhelm the card.
+const MAX_VISIBLE_TECH_ICONS = 8
+
 export default {
   name: 'TheProjectCard',
   props: {
@@ -40,11 +53,25 @@ export default {
     additionalInfo() {
       return Array.isArray(this.project?.additionalInfo) ? this.project.additionalInfo : [];
     },
+    // Content convention in data.json: first additionalInfo item is a
+    // one-sentence summary, the rest are skill highlights.
+    summary() {
+      return this.additionalInfo[0] || '';
+    },
+    highlights() {
+      return this.additionalInfo.slice(1);
+    },
     links() {
       return Array.isArray(this.project?.links) ? this.project.links : [];
     },
     technologyTitles() {
       return Array.isArray(this.project?.technologyTitles) ? this.project.technologyTitles : [];
+    },
+    visibleTechs() {
+      return this.technologyTitles.slice(0, MAX_VISIBLE_TECH_ICONS);
+    },
+    extraTechs() {
+      return this.technologyTitles.slice(MAX_VISIBLE_TECH_ICONS);
     }
   },
   methods: {
@@ -59,37 +86,113 @@ export default {
 
 
 <style scoped>
+/* Tech icons sit in small soft chips — same visual language as the
+   home-page tech chips, scaled down for cards */
+.tech-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 5px;
+  background-color: var(--color-card-bg);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-sm);
+}
+
 .small-devicon {
-  max-width: 45px;
-  max-height: 45px;
-  border-radius: 5px;
+  max-width: 20px;
+  max-height: 20px;
+  border-radius: 3px;
+  display: block;
+}
+
+/* Overflow chip: "+N" for technologies beyond the visible eight */
+.tech-chip-more {
+  background-color: var(--color-primary-light);
+  /* darkest token: AA contrast for small bold text on the pink chip */
+  color: var(--color-primary-dark);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 5px 9px;
+  cursor: default;
 }
 
 .used-technologies {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
+  gap: 6px;
+  margin-bottom: 14px;
+}
+
+/* Lead sentence: what the project is, at a glance */
+.project-summary {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: var(--color-text);
+  margin-bottom: 14px;
+}
+
+/* Skill highlights with small ♡ bullets */
+.project-highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+  display: grid;
+  gap: 6px;
 }
 
 .additional-info {
-  margin-bottom: 0 !important;
-  padding-bottom: 0 !important;
-  color: var(--color-text) !important;
+  position: relative;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--color-text);
+  padding-left: 1.5em;
+  overflow-wrap: break-word;
+}
+
+.additional-info::before {
+  content: '\2661';
+  color: var(--color-primary);
+  position: absolute;
+  left: 0.15em;
+  top: 0;
+  font-size: 0.95em;
+}
+
+/* Project type as a small pill over the image corner */
+.project-type-badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 11px;
+  border-radius: var(--radius-pill);
+  /* whisper-pink surface at high alpha so the label stays readable over any image */
+  background-color: rgba(253, 244, 251, 0.92);
+  color: var(--color-card-heading);
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.5;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  backdrop-filter: blur(4px);
+  box-shadow: var(--shadow-sm);
 }
 
 .project-card {
-  background-color: var(--color-card-bg);
+  /* Whisper pink melting into whisper lilac: airy but never pure white,
+     so the surface stays inside the palette */
+  background: linear-gradient(180deg, var(--color-surface-pink) 0%, var(--color-surface-lilac) 100%);
   font-size: 1rem;
   display: flex;
   flex-direction: column;
   width: 500px;
   margin: 10px;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  transition: transform var(--transition-duration), box-shadow var(--transition-duration);
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease, border-color var(--transition-fast) ease;
+  border: 1px solid var(--color-border-soft);
   flex: 1 1 calc(50% - 20px);
   max-width: 500px;
 }
@@ -97,13 +200,20 @@ export default {
 @media (hover: hover) and (pointer: fine) {
   .project-card:hover {
     transform: translateY(-5px);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-md);
+    border-color: var(--color-primary-light);
+  }
+
+  /* Subtle zoom on the cover image together with the card lift */
+  .project-card:hover .project-image-container img {
+    transform: scale(1.03);
   }
 }
 
 .project-image-container {
+  position: relative;
   overflow: hidden;
-  border-radius: 10px 10px 0 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   flex-shrink: 0;
 }
 
@@ -115,6 +225,8 @@ export default {
   width: 100%;
   height: auto;
   display: block;
+  border-radius: 0;
+  transition: transform var(--transition-medium) ease;
 }
 
 .project-details {
@@ -122,22 +234,16 @@ export default {
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
-  padding: 15px;
+  padding: 18px 20px 20px;
 }
 
 .project-details h3 {
-  /* Mauve heading token: meets AA contrast on the light-pink card background
+  /* Mauve heading token: meets AA contrast on the card surface
      while staying softer than the near-black primary-dark. */
   color: var(--color-card-heading);
-  margin-bottom: 10px;
-  font-size: 1.15rem;
-  overflow-wrap: break-word;
-}
-
-.project-details p {
-  color: var(--color-text);
-  font-size: 0.9em;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
+  font-size: 1.25rem;
+  padding: 0;
   overflow-wrap: break-word;
 }
 
@@ -148,6 +254,8 @@ export default {
   gap: 12px;
   justify-content: flex-start;
   padding-top: 14px;
+  /* Soft hairline separates the action row from the content */
+  border-top: 1px solid var(--color-border-soft);
 }
 
 .project-button {
@@ -161,19 +269,27 @@ export default {
   background-color: var(--color-button);
   text-decoration: none;
   padding: 10px 16px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 600;
   line-height: 1.2;
   text-align: center;
   touch-action: manipulation;
-  transition: background-color var(--transition-duration), color var(--transition-duration), box-shadow var(--transition-duration);
+  transition: background-color var(--transition-fast) ease, color var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
   font-size: 0.95rem;
+}
+
+/* External-link arrow: pseudo-content with empty alt so screen readers
+   skip it (they already get the "opens in new tab" aria-label) */
+.project-button::after {
+  content: '\2197' / '';
+  font-size: 0.85em;
+  margin-left: 6px;
 }
 
 .project-button:hover {
   background-color: var(--color-button-hover);
   color: var(--color-white);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-md);
 }
 
 /* Add focus styles for better keyboard accessibility */
@@ -190,28 +306,24 @@ export default {
 }
 
 @media (max-width: 568px) {
-  .project-details p {
-    font-size: 0.8em;
-    line-height: 1.65;
+  .project-details {
+    padding: 16px;
   }
 
-  .project-details {
-    padding: 10px;
+  .tech-chip {
+    min-width: 30px;
+    min-height: 30px;
+    padding: 4px;
   }
 
   .small-devicon {
-    max-width: 30px;
-    max-height: 30px;
-  }
-
-  .used-technologies {
-    gap: 8px;
+    max-width: 18px;
+    max-height: 18px;
   }
 
   .project-card {
     width: 100%;
     margin: 10px 0;
-    font-size: 0.9rem;
   }
 
   .buttons {
@@ -219,9 +331,10 @@ export default {
     padding-top: 12px;
   }
 
+  /* One comfortable full-width action per row on phones */
   .project-button {
-    min-width: 104px;
-    padding: 9px 14px;
+    width: 100%;
+    padding: 10px 16px;
     font-size: 0.9rem;
   }
 }

--- a/src/main.css
+++ b/src/main.css
@@ -16,46 +16,30 @@ h6 {
   line-height: 1.2;
 }
 
+/* Fluid type scale: one clamp() per level covers mobile through desktop
+   without per-breakpoint overrides. */
 h1 {
-  font-size: calc(1.375rem + 1.5vw);
+  font-size: clamp(1.7rem, 1.25rem + 1.8vw, 2.5rem);
 }
 
 h2 {
-  font-size: calc(1.325rem + 0.9vw);
+  font-size: clamp(1.4rem, 1.1rem + 1.2vw, 2rem);
 }
 
 h3 {
-  font-size: calc(1.3rem + 0.6vw);
+  font-size: clamp(1.2rem, 1rem + 0.8vw, 1.6rem);
 }
 
 h4 {
-  font-size: calc(1.275rem + 0.3vw);
+  font-size: clamp(1.1rem, 0.95rem + 0.6vw, 1.4rem);
 }
 
 h5 {
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 0.9rem + 0.4vw, 1.2rem);
 }
 
 h6 {
   font-size: 1rem;
-}
-
-@media (min-width: 1200px) {
-  h1 {
-    font-size: 2.5rem;
-  }
-
-  h2 {
-    font-size: 2rem;
-  }
-
-  h3 {
-    font-size: 1.75rem;
-  }
-
-  h4 {
-    font-size: 1.5rem;
-  }
 }
 
 ol,
@@ -269,7 +253,7 @@ html {
 body {
   background-color: var(--color-background);
   min-height: 100vh;
-  line-height: 1.9;
+  line-height: 1.75;
   font-family: 'Comfortaa', sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -288,6 +272,7 @@ h1, h2, h3, h4, h5 {
   color: var(--color-heading);
   margin-bottom: 1.5rem;
   font-weight: 700;
+  letter-spacing: 0.015em;
 }
 
 label {
@@ -311,11 +296,10 @@ h2 {
 
 /* Section spacing */
 section {
-  margin-top: 15px;
+  margin-top: clamp(1.75rem, 4vw, 2.75rem);
 }
 
 h3 {
-  font-size: 1.5rem;
   padding: 10px 0;
 }
 
@@ -325,14 +309,14 @@ h4, h5 {
 
 /* Images */
 img {
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
 }
 
 /* Paragraphs */
 p {
   color: var(--color-text);
   margin-bottom: 25px;
-  font-size: 1.1rem;
+  font-size: clamp(0.95rem, 0.9rem + 0.3vw, 1.1rem);
 }
 
 /* Links */
@@ -362,32 +346,38 @@ li {
   color: #c62828;
   background-color: #ffebee;
   padding: 15px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   margin-bottom: 20px;
   text-align: center;
 }
 
-/* Mobile styles */
-@media (max-width: 568px) {
-  h1 {
-    font-size: 1.6rem !important;
-    padding: 10px 0 15px;
-  }
+/* Decorative section divider: soft gradient hairline with a ♡ centerpiece.
+   Always used on aria-hidden elements — the glyph is purely visual. */
+.section-divider {
+  position: relative;
+  height: 1px;
+  max-width: min(420px, 70%);
+  margin: clamp(1.75rem, 4vw, 2.75rem) auto;
+  background: linear-gradient(to right, transparent, var(--color-primary-light), transparent);
+}
 
-  h2 {
-    font-size: 1.4rem !important;
-    padding: 15px 0 10px;
-  }
+.section-divider::before {
+  content: '♡';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0 14px;
+  background-color: var(--color-background);
+  color: var(--color-primary);
+  font-size: 1.05rem;
+  line-height: 1;
+}
 
-  h3 {
-    font-size: 1.2rem !important;
-  }
-
-  h4 {
-    font-size: 1.1rem !important;
-  }
-
-  h5 {
-    font-size: 1rem !important;
-  }
+/* Soft gradient wash behind featured sections (yume, contact): gentle depth
+   while text still sits on an effectively near-background surface. */
+.section-wash {
+  background: linear-gradient(165deg, var(--color-primary-soft), rgba(241, 199, 232, 0.12) 55%, transparent);
+  border-radius: var(--radius-lg);
+  padding: clamp(16px, 3.5vw, 32px);
 }

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -38,10 +38,12 @@
         </div>
       </div>
 
-      <div class="col-md-auto">
+      <div class="col-md-auto profile-col">
         <img src="/assets/profile/angelica-profilepic.webp" class="img-responsive profilepic" :alt="$t('intro.profileImageAlt')" fetchpriority="high">
       </div>
     </div>
+
+    <div class="section-divider" aria-hidden="true"></div>
 
     <section class="education">
       <div class="heartlist">
@@ -66,7 +68,9 @@
       </div>
     </section>
 
-    <section class="interesting-fact">
+    <div class="section-divider" aria-hidden="true"></div>
+
+    <section class="interesting-fact section-wash">
       <h2>
         {{ $t('yume.titleStart') }}
         <span class="tooltip-container" tabindex="0" :aria-label="$t('yume.ariaLabel')" @focus="isTooltipVisible = true"
@@ -80,7 +84,9 @@
       <p>{{ $t('yume.text') }}</p>
     </section>
 
-    <section class="commitment">
+    <div class="section-divider" aria-hidden="true"></div>
+
+    <section class="commitment section-wash">
       <h2>{{ $t('drives.title') }}</h2>
       <p>
         <template v-for="(segment, index) in $tm('drives.segments')" :key="`drives-${index}`">
@@ -91,7 +97,9 @@
 
     </section>
 
-    <section class="contact">
+    <div class="section-divider" aria-hidden="true"></div>
+
+    <section class="contact section-wash">
       <h2 id="contact">{{ $t('contact.title') }}</h2>
       <p>{{ $t('contact.linkedinPrompt') }}</p>
 
@@ -101,19 +109,25 @@
 
       <p>{{ $t('contact.githubPrompt') }}</p>
 
-      <p class="introduction-highlights-paragraph">
-        <a href="https://www.linkedin.com/in/yumeangelica/" target="_blank"
+      <div class="contact-buttons">
+        <a href="https://www.linkedin.com/in/yumeangelica/" class="contact-button" target="_blank"
           :aria-label="$t('common.externalLinkAriaLabel', { label: $t('contact.visitLinkedin') })" rel="noopener">
-          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/linkedin/linkedin-original-wordmark.svg" alt=""
-            loading="lazy" />
+          <svg class="contact-button-icon" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <path
+              d="M20.45 20.45h-3.55v-5.57c0-1.33-.03-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.36V9h3.41v1.56h.05c.47-.9 1.63-1.85 3.36-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.55C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.72C24 .77 23.2 0 22.22 0z" />
+          </svg>
+          {{ $t('nav.linkedin') }}
         </a>
 
-        <a href="https://github.com/yumeangelica" target="_blank"
+        <a href="https://github.com/yumeangelica" class="contact-button" target="_blank"
           :aria-label="$t('common.externalLinkAriaLabel', { label: $t('contact.visitGithub') })" rel="noopener">
-          <img class="contact-icon" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original-wordmark.svg" alt=""
-            loading="lazy" />
+          <svg class="contact-button-icon" aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <path
+              d="M12 .3a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.33-1.76-1.33-1.76-1.09-.74.08-.73.08-.73 1.2.09 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.5 1 .1-.78.42-1.31.76-1.61-2.66-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18a4.65 4.65 0 0 1 1.23 3.22c0 4.61-2.8 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58A12 12 0 0 0 12 .3z" />
+          </svg>
+          {{ $t('nav.github') }}
         </a>
-      </p>
+      </div>
     </section>
   </template>
 </template>
@@ -166,13 +180,24 @@ export default {
 .devicon-wrapper {
   position: relative;
   display: inline-block;
+  background-color: var(--color-card-bg);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-md);
+  padding: 8px;
+  transition: transform var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .devicon-wrapper:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-sm);
+  }
 }
 
 .devicon {
-  width: 65px;
-  max-width: 65px;
+  width: 48px;
+  max-width: 48px;
   display: block;
-  padding: 2px;
   border-radius: 5px;
 }
 
@@ -194,7 +219,7 @@ export default {
   white-space: normal;
   pointer-events: none;
   transition: opacity 0.15s ease;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   margin-bottom: 4px;
 }
 
@@ -203,34 +228,77 @@ export default {
   opacity: 1;
 }
 
-.contact-icon {
-  max-width: 80px;
-  margin-right: 25px;
-  margin-bottom: 15px;
-  border-radius: 5px;
-  transition: transform var(--transition-duration) ease;
-}
-
 .contact-image {
   max-width: 90%;
   width: 320px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
 }
 
-.contact-icon:hover {
-  transform: scale(1.05);
-  cursor: pointer;
+/* Social pill buttons: same visual language as project-card buttons */
+.contact-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 25px;
 }
 
+.contact-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 48px;
+  min-width: 150px;
+  padding: 10px 24px;
+  color: var(--color-white);
+  background-color: var(--color-button);
+  border-radius: var(--radius-pill);
+  text-decoration: none;
+  font-weight: 600;
+  line-height: 1.2;
+  touch-action: manipulation;
+  transition: background-color var(--transition-fast) ease, box-shadow var(--transition-fast) ease;
+}
+
+.contact-button:hover {
+  background-color: var(--color-button-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.contact-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  background-color: var(--color-button-hover);
+}
+
+.contact-button-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+/* Photo column centers vertically against the intro text */
+.profile-col {
+  align-self: center;
+}
+
+/* Photo keeps its natural 4:5 proportions: soft rounded rectangle with a
+   thin pink border — no crop, no circle */
 .profilepic {
+  display: block;
   width: 100%;
   max-width: 300px;
   margin: 10px 0 20px 35px;
+  border: 2px solid var(--color-primary-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
 }
 
 @media (max-width: 991px) {
   .profilepic {
-    margin: 10px auto;
-    display: block;
+    max-width: 260px;
+    margin: 15px auto 28px;
   }
 }
 
@@ -248,9 +316,9 @@ export default {
 }
 
 .heartlist li {
-  font-size: 1.1rem;
+  font-size: clamp(0.95rem, 0.9rem + 0.3vw, 1.1rem);
   position: relative;
-  padding: 1px 0;
+  padding: 3px 0;
 }
 
 .introduction-highlights-paragraph {
@@ -279,9 +347,10 @@ export default {
   width: auto;
   color: var(--color-primary);
   text-align: center;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 5px 10px;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  background-color: var(--color-background);
+  box-shadow: var(--shadow-lg);
   max-width: min(280px, calc(100vw - 32px));
   overflow-wrap: break-word;
   transition: opacity 0.4s ease, visibility 0.4s ease;
@@ -310,8 +379,8 @@ export default {
   color: var(--color-primary);
   text-decoration: none;
   border-bottom: 1px solid var(--color-primary);
-  transition: color var(--transition-duration) ease,
-    border-bottom-color var(--transition-duration) ease;
+  transition: color var(--transition-fast) ease,
+    border-bottom-color var(--transition-fast) ease;
 }
 
 .styled-link:hover {
@@ -322,33 +391,35 @@ export default {
 /* Mobile mode rules */
 @media (max-width: 568px) {
   .devicon {
-    width: 45px;
-    max-width: 45px;
+    width: 36px;
+    max-width: 36px;
+  }
+
+  .devicon-wrapper {
+    padding: 6px;
+    border-radius: var(--radius-sm);
   }
 
   .tech-category .introduction-highlights-paragraph {
     gap: 10px;
   }
 
-  .contact-icon {
-    max-width: 55px;
-  }
-
   .contact-image {
     max-width: 85%;
   }
 
-  .heartlist li,
-  p {
-    font-size: 0.9rem;
+  /* Full-width stacked buttons: easy thumb targets on phones */
+  .contact-button {
+    width: 100%;
+    max-width: 320px;
   }
 
   .heartlist ul li:before {
-    font-size: 0.9rem;
+    font-size: 0.95rem;
   }
 
   .profilepic {
-    max-width: 200px;
+    max-width: 220px;
   }
 
   .tooltip-text {
@@ -366,12 +437,6 @@ export default {
     visibility: visible;
     opacity: 1;
   }
-}
-
-/* Improve focus visibility for links */
-a:focus-visible {
-  outline: 3px solid var(--color-primary);
-  outline-offset: 2px;
 }
 
 /* Ensure tooltip is visible when focused via keyboard */

--- a/src/pages/PageProjects.vue
+++ b/src/pages/PageProjects.vue
@@ -7,27 +7,39 @@
     <div class="filter-container">
       <!-- Unified filter row: two centered rows, always visible on all devices -->
       <div class="filters-row">
-        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filters.typeGroupAriaLabel')">
-          <button type="button" @click="toggleTypeFilter(null)" class="filter-btn filter-type" :class="{ active: selectedTypes.length === 0 }"
-            :aria-label="$t('projects.filters.allTypesAriaLabel')">
-            {{ $t('projects.filters.allLabel') }}
-          </button>
-          <button type="button" v-for="type in typeFilters" :key="type" @click="toggleTypeFilter(type)" class="filter-btn filter-type"
-            :class="{ active: selectedTypes.includes(type) }" :disabled="!isTypeTechComboAvailable(type, selectedTech)"
-            :aria-label="$t(`projects.filters.types.${type}.ariaLabel`)">
-            {{ $t(`projects.filters.types.${type}.label`) }}
-          </button>
+        <div class="filter-group">
+          <span class="filter-label">{{ $t('projects.filters.typeLabel') }}</span>
+          <div class="filter-row-inner filter-row-type" role="group" :aria-label="$t('projects.filters.typeGroupAriaLabel')">
+            <button type="button" @click="toggleTypeFilter(null)" class="filter-btn filter-type" :class="{ active: selectedTypes.length === 0 }"
+              :aria-label="$t('projects.filters.allTypesAriaLabel')">
+              {{ $t('projects.filters.allLabel') }}
+            </button>
+            <button type="button" v-for="type in typeFilters" :key="type" @click="toggleTypeFilter(type)" class="filter-btn filter-type"
+              :class="{ active: selectedTypes.includes(type) }" :disabled="!isTypeTechComboAvailable(type, selectedTech)"
+              :aria-label="$t(`projects.filters.types.${type}.ariaLabel`)">
+              {{ $t(`projects.filters.types.${type}.label`) }}
+            </button>
+          </div>
         </div>
-        <div class="filter-row-inner" role="group" :aria-label="$t('projects.filters.techGroupAriaLabel')">
-          <button type="button" @click="toggleTechFilter(null)" class="filter-btn tech-filter-btn" :class="{ active: selectedTech.length === 0 }"
-            :aria-label="$t('projects.filters.allTechAriaLabel')">
-            <span>{{ $t('projects.filters.allLabel') }}</span>
+        <div class="filter-group">
+          <button type="button" class="filter-panel-toggle" @click="isTechFiltersOpen = !isTechFiltersOpen" :aria-expanded="isTechFiltersOpen"
+            aria-controls="technology-filters" :aria-label="$t('projects.filters.techToggleAriaLabel', { count: selectedTech.length })">
+            <span>{{ $t('projects.filters.techLabel') }}</span>
+            <span v-if="selectedTech.length > 0" class="filter-count" aria-hidden="true">{{ selectedTech.length }}</span>
+            <span class="filter-chevron" :class="{ open: isTechFiltersOpen }" aria-hidden="true">⌄</span>
           </button>
-          <button type="button" v-for="tech in popularTechnologies" :key="tech.title" @click="toggleTechFilter(tech.title)" class="filter-btn tech-filter-btn"
-            :class="{ active: selectedTech.includes(tech.title) }" :disabled="!isTechTypeComboAvailable(tech.title, selectedTypes)"
-            :aria-label="$t('projects.filters.techAriaLabel', { title: tech.title })">
-            <img :src="tech.url" :alt="tech.title" :title="tech.title" class="tech-icon" />
-          </button>
+          <div v-show="isTechFiltersOpen" id="technology-filters" class="filter-row-inner filter-row-tech" role="group"
+            :aria-label="$t('projects.filters.techGroupAriaLabel')">
+            <button type="button" @click="toggleTechFilter(null)" class="filter-btn tech-filter-btn tech-filter-all" :class="{ active: selectedTech.length === 0 }"
+              :aria-label="$t('projects.filters.allTechAriaLabel')">
+              <span>{{ $t('projects.filters.allLabel') }}</span>
+            </button>
+            <button type="button" v-for="tech in popularTechnologies" :key="tech.title" @click="toggleTechFilter(tech.title)" class="filter-btn tech-filter-btn"
+              :class="{ active: selectedTech.includes(tech.title) }" :disabled="!isTechTypeComboAvailable(tech.title, selectedTypes)"
+              :aria-label="$t('projects.filters.techAriaLabel', { title: tech.title })">
+              <img :src="tech.url" :alt="tech.title" :title="tech.title" class="tech-icon" />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -108,6 +120,7 @@ export default {
       loading: true, // For accessibility, show loading message while fetching data
       showFloatingNav: false, // Show floating nav when scrolled
       isFloatingMenuOpen: false, // Toggle for floating menu
+      isTechFiltersOpen: false, // Mobile disclosure for the technology filter grid
       scrollTimeout: null, // For throttling scroll events
     }
   },
@@ -325,15 +338,82 @@ export default {
   padding-bottom: 50px;
 }
 
-/* Compact unified filter row */
+/* Mobile-first filters: wrapping pill rows that fit any viewport width;
+   the technology menu is a disclosure panel on every screen size */
+.filter-container {
+  max-width: 780px;
+  margin: 0 auto 32px;
+  padding: 0 8px;
+}
+
 .filters-row {
+  display: grid;
+  gap: 10px;
+}
+
+.filter-group {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+}
+
+.filter-label {
+  color: var(--color-primary-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.filter-panel-toggle {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  margin-bottom: 18px;
-  padding: 0 4px;
+  width: min(100%, 320px);
+  min-height: 44px;
+  padding: 8px 14px;
+  color: var(--color-primary-dark);
+  background:
+    linear-gradient(150deg, rgba(255, 255, 255, 0.62), rgba(253, 244, 251, 0.96)),
+    var(--color-surface-pink);
+  border: 1.5px solid var(--color-primary-light);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-sm);
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.filter-panel-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.filter-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
+  color: var(--color-white);
+  background-color: var(--color-primary);
+  border-radius: var(--radius-pill);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.filter-chevron {
+  margin-left: auto;
+  color: var(--color-primary);
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform var(--transition-fast) ease;
+}
+
+.filter-chevron.open {
+  transform: rotate(180deg);
 }
 
 .filter-row-inner {
@@ -341,7 +421,15 @@ export default {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
+  width: 100%;
+  padding: 7px;
+  background:
+    linear-gradient(150deg, rgba(255, 255, 255, 0.58), rgba(253, 244, 251, 0.94)),
+    var(--color-surface-pink);
+  border: 1px solid var(--color-border-soft);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Filter-btn for all filter buttons */
@@ -350,23 +438,31 @@ export default {
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 0.85rem;
-  border-radius: 16px;
-  padding: 4px 10px;
-  min-width: 0;
+  font-size: 0.88rem;
+  border-radius: var(--radius-pill);
+  padding: 6px 12px;
+  min-width: 44px;
+  min-height: 44px;
   cursor: pointer;
   touch-action: manipulation;
   transition:
-    background-color var(--transition-duration) ease,
-    border-color var(--transition-duration) ease,
-    box-shadow var(--transition-duration) ease,
-    color var(--transition-duration) ease,
-    filter var(--transition-duration) ease,
-    opacity var(--transition-duration) ease;
+    background-color var(--transition-fast) ease,
+    border-color var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease,
+    color var(--transition-fast) ease,
+    filter var(--transition-fast) ease,
+    opacity var(--transition-fast) ease;
   background-color: var(--color-card-bg);
   color: var(--color-text);
   border: 1.5px solid var(--color-primary-light);
   opacity: 0.95;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .filter-btn:not(:disabled):not(.active):hover {
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-sm);
+  }
 }
 
 .filter-btn.active {
@@ -374,7 +470,7 @@ export default {
   color: var(--color-white);
   border-color: var(--color-primary);
   font-weight: 600;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   opacity: 1;
 }
 
@@ -395,15 +491,13 @@ export default {
 }
 
 .tech-filter-btn {
-  gap: 2px;
-  min-height: 28px;
-  line-height: 1.1;
-  padding: 4px 7px;
+  width: 44px;
+  padding: 0;
 }
 
-.tech-filter-btn span {
-  display: inline;
-  font-size: 0.85rem;
+.tech-filter-all {
+  width: auto;
+  padding: 0 14px;
 }
 
 .tech-icon {
@@ -412,13 +506,58 @@ export default {
   border-radius: 3px;
 }
 
+/* Larger screens: panels hug their content instead of stretching full width */
+@media (min-width: 769px) {
+  .filter-container {
+    padding: 0 10px;
+  }
+
+  .filters-row {
+    gap: 12px;
+  }
+
+  .filter-group {
+    gap: 6px;
+  }
+
+  .filter-row-inner {
+    gap: 7px;
+    width: fit-content;
+    max-width: 100%;
+    padding: 8px;
+  }
+
+  .filter-row-tech {
+    width: min(100%, 650px);
+  }
+}
+
+/* Section headings: small centered hairline accent, same visual language
+   as the home-page dividers */
+section h2 {
+  position: relative;
+  padding-bottom: 18px;
+}
+
+section h2::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 8px;
+  transform: translateX(-50%);
+  width: min(140px, 40%);
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(to right, transparent, var(--color-primary-light), transparent);
+}
+
 /* Project containers */
 .projects-container {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  gap: 20px;
+  gap: clamp(16px, 2.5vw, 24px);
   align-items: stretch;
   padding: 10px;
   margin-bottom: 30px;
@@ -432,74 +571,7 @@ export default {
     align-items: center;
     padding: 0;
   }
-
-  .filter-container {
-    margin-bottom: 30px;
-    padding: 0 10px;
-  }
-
-  .filters-row {
-    gap: 8px;
-    margin-bottom: 12px;
-    background: none;
-    border-radius: 0;
-    box-shadow: none;
-    border: none;
-    max-width: 98vw;
-    width: 100%;
-    transition: none;
-    z-index: 20;
-  }
-
-  .filter-row-inner {
-    gap: 8px;
-    width: 100%;
-    justify-content: center;
-  }
-
-  .filter-btn {
-    min-width: 44px;
-    min-height: 36px;
-    font-size: 0.92rem;
-    border-radius: 14px;
-    box-shadow: none;
-    background: var(--color-white);
-    border: 1.5px solid var(--color-primary-light);
-  }
-
-  .filter-btn.active {
-    background: var(--color-primary);
-    color: var(--color-white);
-    border-color: var(--color-primary);
-  }
-
-  .filter-btn:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
-  }
-
-  .tech-icon {
-    width: 20px;
-    height: 20px;
-  }
-
 }
-
-@media (max-width: 568px) {
-  .filter-btn {
-    padding: 3px 6px;
-  }
-}
-
-/* Very small mobile specific adjustments */
-@media (max-width: 400px) {
-  .tech-icon {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-
 
 /* Floating navigation styles */
 .floating-nav {
@@ -525,17 +597,17 @@ export default {
   align-items: center;
   justify-content: center;
   font-size: 1.2rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   transition:
-    background-color var(--transition-duration) ease,
-    box-shadow var(--transition-duration) ease,
-    transform var(--transition-duration) ease;
+    background-color var(--transition-fast) ease,
+    box-shadow var(--transition-fast) ease,
+    transform var(--transition-fast) ease;
 }
 
 .floating-nav-toggle:hover {
   background-color: var(--color-primary-dark);
   transform: translateY(-2px);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--shadow-lg);
 }
 
 .floating-nav-toggle:focus-visible {
@@ -555,15 +627,15 @@ export default {
   position: absolute;
   bottom: 60px;
   right: 0;
-  background-color: var(--color-white);
-  border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  background-color: var(--color-surface-lilac);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
   padding: 10px;
   display: flex;
   flex-direction: column;
   gap: 5px;
   min-width: 120px;
-  border: 1px solid var(--color-primary-light);
+  border: 1px solid var(--color-border-soft);
 }
 
 .floating-nav-button {
@@ -571,13 +643,13 @@ export default {
   background-color: transparent;
   color: var(--color-text);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.9rem;
   text-align: left;
   transition:
-    background-color var(--transition-duration) ease,
-    color var(--transition-duration) ease;
+    background-color var(--transition-fast) ease,
+    color var(--transition-fast) ease;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary

Mobile-first UI refresh for the whole portfolio: a shared design-token layer (soft surfaces, plum shadows, radii, motion), a fluid clamp()-based type scale, redesigned navbar/header/footer accents, reworked home and projects pages, and condensed project copy. The projects-page technology filter is now a disclosure menu that works on every screen size with no horizontal overflow, and the profile photo is back to a soft rounded rectangle in its natural 4:5 proportions with a thin pink border.

## What changed

- **Design tokens** (`src/base.css`): derived tints (`--color-primary-soft`, `--color-border-soft`), whisper pink/lilac surface tokens, layered plum-tinted shadows, radius scale, and fast/medium transition tokens. Existing `--color-*` brand tokens are untouched.
- **Global styles** (`src/main.css`, `src/App.vue`): clamp()-based fluid type scale replacing per-breakpoint font overrides, fluid container gutters, heart section dividers, and section wash backgrounds.
- **Navbar** (`TheNavBar.vue`): gradient underline hover/active indicators, Escape closes the mobile menu, 44px touch rows, gentle menu reveal animation (respects reduced motion).
- **Header & footer**: banner ends in a soft gradient veil that blends into the navbar; footer gets a hairline divider and a decorative ♡.
- **Home page** (`PageHome.vue`): section washes and dividers, tech icons in soft chips, contact links as pill buttons with inline SVG icons, and the profile photo restored to a natural-ratio (4:5) soft rectangle with a thin `--color-primary-light` border — no crop, no circle, no thick frame.
- **Projects page** (`PageProjects.vue`): filters rebuilt mobile-first — base styles target mobile with a single `min-width` enhancement; type filters are wrapping pills (the rigid 5-column grid that overflowed narrow viewports is gone); the technology filter is a disclosure menu (toggle + collapsible icon panel, `v-show` + `aria-expanded`) on all screen sizes with a selected-count badge.
- **Project cards** (`TheProjectCard.vue`): type badge, one-sentence summary + highlight list split, tech icons in chips with a "+N" overflow chip (full list kept for screen readers).
- **Content** (`public/data.json`): project descriptions condensed to a summary line plus highlights to match the new card layout.
- **i18n** (`public/messages_en.json`): three new filter keys (`typeLabel`, `techLabel`, `techToggleAriaLabel`).
- **Tests**: new/updated component tests for the filter toggle, navbar Escape behavior, home page, and project cards (54 tests total).
- Version bump 2.6.0 → 2.7.0.